### PR TITLE
Add 'autoplay', 'controls', 'loop' to embedded player options

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -400,6 +400,15 @@ get "/embed/:id" do |env|
   end
   listen ||= false
 
+  autoplay = env.params.query["autoplay"]?.try &.to_i
+  autoplay ||= 0
+
+  controls = env.params.query["controls"]?.try &.to_i
+  controls ||= 1
+
+  video_loop = env.params.query["loop"]?.try &.to_i
+  video_loop ||= 0
+
   client = make_client(YT_URL)
   begin
     video = get_video(id, client, PG_DB)

--- a/src/invidious/views/embed.ecr
+++ b/src/invidious/views/embed.ecr
@@ -29,7 +29,7 @@ video, #my_video, .video-js, .vjs-default-skin
 }
 </style>
 
-<video playsinline poster="<%= thumbnail %>" title="<%= HTML.escape(video.title) %>" id="player" class="video-js vjs-default-skin" controls>
+<video playsinline poster="<%= thumbnail %>" title="<%= HTML.escape(video.title) %>" id="player" class="video-js vjs-default-skin">
     <% if listen %>
         <% audio_streams.each_with_index do |fmt, i| %>
             <source src="<%= fmt["url"] %>" type='<%= fmt["type"] %>' label="<%= fmt["bitrate"] %>k" selected="<%= i == 0 ? true : false %>">
@@ -44,6 +44,9 @@ video, #my_video, .video-js, .vjs-default-skin
 <script>
 var options = {
     preload: "auto",
+    <% if autoplay == 1 %>autoplay: true, <% end %>
+    <% if controls == 1 %>controls: true, <% end %>
+    <% if video_loop == 1 %>loop: true, <% end %>
     playbackRates: [0.5, 1, 1.5, 2],
     controlBar: {
       children: [


### PR DESCRIPTION
Taking a second look at the supported [player options](https://developers.google.com/youtube/player_parameters), it looks like these are the most significant, except for playlists, which aren't yet implemented.

Wondering if any others should be added.