### PR TITLE
Add non-Google accounts

### DIFF
--- a/config/sql/users.sql
+++ b/config/sql/users.sql
@@ -10,6 +10,7 @@ CREATE TABLE public.users
     subscriptions text[] COLLATE pg_catalog."default",
     email text COLLATE pg_catalog."default" NOT NULL,
     preferences text COLLATE pg_catalog."default",
+    password text COLLATE pg_catalog."default",
     CONSTRAINT users_email_key UNIQUE (email),
     CONSTRAINT users_id_key UNIQUE (id)
 )

--- a/src/invidious/views/login.ecr
+++ b/src/invidious/views/login.ecr
@@ -6,24 +6,51 @@
     <div class="pure-u-1 pure-u-md-1-5"></div>
     <div class="pure-u-1 pure-u-md-3-5">
         <div class="h-box">
+            <div class="pure-g">
+                <div class="pure-u-1 pure-u-md-1-2">
+                    <a class="pure-button <% if account_type == "google" %>pure-button-disabled<% end %>" href="/login">Login to Google</a>
+                </div>
+                <div class="pure-u-1 pure-u-md-1-2">
+                    <a class="pure-button <% if account_type == "invidious" %>pure-button-disabled<% end %>" href="/login?type=invidious">Login/Register</a>
+                </div>
+            </div>
+            <hr>
+            <% if account_type == "google" %>
             <form class="pure-form pure-form-stacked" action="/login?referer=<%= referer %>" method="post">
                 <fieldset>
-                    <legend>Login to Google</legend>
-
                     <label for="email">Email</label>
-                    <input class="pure-input-1" name="email" type="email" placeholder="Email">
+                    <input required class="pure-input-1" name="email" type="email" placeholder="Email">
 
                     <label for="password">Password</label>
-                    <input class="pure-input-1" name="password" type="password" placeholder="Password">
+                    <input required class="pure-input-1" name="password" type="password" placeholder="Password">
                     
                     <% if tfa %>
                     <label for="tfa">Google verification code</label>
-                    <input class="pure-input-1" name="tfa" type="text" placeholder="Google verification code">
+                    <input required class="pure-input-1" name="tfa" type="text" placeholder="Google verification code">
                     <% end %>
 
                     <button type="submit" class="pure-button pure-button-primary">Sign in</button>
                 </fieldset>
             </form>
+            <% elsif account_type == "invidious" %>
+            <form class="pure-form pure-form-stacked" action="/login?referer=<%= referer %>&type=invidious" method="post">
+                <fieldset>
+                    <label for="email">User ID:</label>
+                    <input required class="pure-input-1" name="email" type="text" placeholder="User ID">
+
+                    <label for="password">Password</label>
+                    <input required class="pure-input-1" name="password" type="password" placeholder="Password">
+                
+                    <img src='<%= captcha.not_nil![:challenge] %>'/>
+                    <input type="hidden" name="token" value="<%= captcha.not_nil![:token] %>">
+                    <label for="challenge_response">Time (hh:mm):</label>
+                    <input required type="text" name="challenge_response" type="text>" placeholder="hh:mm">
+
+                    <button type="submit" name="action" value="signin" class="pure-button pure-button-primary">Sign In</button>
+                    <button type="submit" name="action" value="register" class="pure-button pure-button-primary">Register</button>
+                </fieldset>
+            </form>
+            <% end %>
         </div>
     </div>
     <div class="pure-u-1 pure-u-md-1-5"></div>


### PR DESCRIPTION
Closes #10.
Adds non-Google accounts which share all the same functionality.

A couple notes:
- When registering, there is no need to use an email
- Multiple (simultaneous) sessions are not yet supported
- Should be faster than Google accounts (no need to inform Google when subscriptions change, etc)

Thank you to reddit user [/u/Privanoid](https://www.reddit.com/user/Privanoid) for suggesting clock CAPTCHA used in sign in and registering. The CAPTCHA can be made more rigorous as need arises (second hand, tweaking background color, etc). 

Folks planning on using this feature should look through these changes, especially [here](https://github.com/omarroth/invidious/blob/719dc11dea549d9866f3c178af23c978f869e7e1/src/invidious.cr#L712-L792) and [here](https://github.com/omarroth/invidious/blob/719dc11dea549d9866f3c178af23c978f869e7e1/src/invidious/helpers.cr#L822-L827) to ensure that their account info is kept secure to their satisfaction.