### PR TITLE
Add Atom feed

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -1022,11 +1022,11 @@ get "/feed/private" do |env|
   case sort
   when "alphabetically"
     videos.sort_by! { |video| video.title }
-  when "alphabetically - reverse"
+  when "reverse_alphabetically"
     videos.sort_by! { |video| video.title }.reverse!
-  when "channel name"
+  when "channel_name"
     videos.sort_by! { |video| video.author }
-  when "channel name - reverse"
+  when "reverse_channel_name"
     videos.sort_by! { |video| video.author }.reverse!
   end
 

--- a/src/invidious/helpers.cr
+++ b/src/invidious/helpers.cr
@@ -139,6 +139,7 @@ class User
       converter: PreferencesConverter,
     },
     password: String?,
+    token:    String,
   })
 end
 
@@ -815,13 +816,17 @@ def fetch_user(sid, client, headers, db)
     email = ""
   end
 
-  user = User.new(sid, Time.now, [] of String, channels, email, DEFAULT_USER_PREFERENCES, nil)
+  token = Base64.encode(Random::Secure.random_bytes(32))
+
+  user = User.new(sid, Time.now, [] of String, channels, email, DEFAULT_USER_PREFERENCES, nil, token)
   return user
 end
 
 def create_user(sid, email, password)
   password = Crypto::Bcrypt::Password.create(password, cost: 10)
-  user = User.new(sid, Time.now, [] of String, [] of String, email, DEFAULT_USER_PREFERENCES, password.to_s)
+  token = Base64.encode(Random::Secure.random_bytes(32))
+
+  user = User.new(sid, Time.now, [] of String, [] of String, email, DEFAULT_USER_PREFERENCES, password.to_s, token)
 
   return user
 end

--- a/src/invidious/views/subscriptions.ecr
+++ b/src/invidious/views/subscriptions.ecr
@@ -2,7 +2,19 @@
 <title>Subscriptions - Invidious</title>
 <% end %>
 
-<h3><a href="/subscription_manager">Manage subscriptions</a></h3>
+<div class="pure-g">
+    <div class="pure-u-1 pure-u-md-3-5">
+        <h3>
+            <a href="/subscription_manager">Manage subscriptions</a>
+        </h3>
+    </div>
+    <div class="pure-u-1 pure-u-md-1-5"></div>
+    <div style="text-align:right;" class="pure-u-1 pure-u-md-1-5">
+        <h3>
+            <a href="/feed/private?token=<%= user.token %>"><i class="fas fa-rss-square"></i></a>
+        </h3>
+    </div>
+</div>
 
 <% if !notifications.empty? %>
     <% notifications.each_slice(4) do |slice| %>
@@ -26,13 +38,13 @@
 <div class="pure-g">
     <div class="pure-u-1 pure-u-md-1-5">
     <% if page > 2 %>
-        <a href="/feed/subscriptions?maxResults=<%= max_results %>&page=<%= page - 1 %>">Previous page</a>
+        <a href="/feed/subscriptions?max_results=<%= max_results %>&page=<%= page - 1 %>">Previous page</a>
     <% else %>
-        <a href="/feed/subscriptions?maxResults=<%= max_results %>">Previous page</a>
+        <a href="/feed/subscriptions?max_results=<%= max_results %>">Previous page</a>
     <% end %>
     </div>
     <div class="pure-u-1 pure-u-md-3-5"></div>
     <div style="text-align:right;" class="pure-u-1 pure-u-md-1-5">
-        <a href="/feed/subscriptions?maxResults=<%= max_results %>&page=<%= page + 1 %>">Next page</a>
+        <a href="/feed/subscriptions?max_results=<%= max_results %>&page=<%= page + 1 %>">Next page</a>
     </div>
 </div>


### PR DESCRIPTION
Closes #11.
Generates a custom token for a user to access their feed from the `/feed/subscriptions` page. All subscription preferences (`sort`, `latest_only`, `max_results`) can be changed using query parameters. For example:
```
/feed/private?token=AAAAA&max_results=10&sort=alphabetically&latest_only=1
```
I'm wondering if the subscriptions page should link to a feed that is automatically customized to the user's preferences, or if that would be more counter-intuitive than convenient.

Currently works as expected in [Akregator](https://www.kde.org/applications/internet/akregator/), although it would be good to try it in other readers that folks are using.