### PR TITLE
Split Reddit comments into separate request

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -12,3 +12,16 @@ div {
   overflow-wrap: break-word;
   word-wrap: break-word;
 }
+
+.loading {
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -133,6 +133,41 @@ for ( var i = 0; i < currentSources.length; i++ ) {
 
 player.src(currentSources);
 <% end %>
+
+fetch("/comments/<%= video.id %>?source=reddit")
+    .then(function(response) {
+        return response.json();
+    })
+    .then(function(jsonResponse) {
+        comments = document.getElementById('comments');
+        comments.innerHTML = `
+        <div>
+            <h3>
+                <a href="javascript:void(0)" onclick="toggle_comments(this)">[ - ]</a> 
+                {title}
+            </h3>
+            <b>
+                <a target="_blank" href="https://reddit.com{permalink}">View more comments on Reddit</a>
+            </b>
+        </div>
+        <div>{content_html}</div>
+    </div>
+    <hr style="margin-left:1em; margin-right:1em;">`.supplant({
+        title: jsonResponse.title,
+        permalink: jsonResponse.permalink,
+        content_html: jsonResponse.content_html
+        })
+    });
+
+String.prototype.supplant = function (o) {
+    return this.replace(/{([^{}]*)}/g,
+        function (a, b) {
+            var r = o[b];
+            return typeof r === 'string' || typeof r === 'number' ? r : a;
+        }
+    );
+};
+
 </script>
 
 <div class="h-box">
@@ -207,26 +242,11 @@ player.src(currentSources);
                 <%= video.description %>
             </div>
             <hr style="margin-left:1em; margin-right:1em;">
-        <% if reddit_thread  && !reddit_html.empty? %>
-            <div id="Comments">
-                <div>
-                    <h3>
-                        <a href="javascript:void(0)" onclick="toggle_comments(this)">[ - ]</a> 
-                        <%= reddit_thread.title %>
-                    </h3>
-                    <b>
-                        <a target="_blank" href="https://reddit.com<%= reddit_thread.permalink %>">View more comments on Reddit</a>
-                    </b>
-                </div>
-                <div>
-                    <%= reddit_html %>
-                </div>
+            <div id="comments">
+                <h3><center><i class="loading fas fa-spinner"></i></center></h3>
             </div>
-            <hr style="margin-left:1em; margin-right:1em;">
-        <% end %>
         </div>
     </div>
-
     <div class="pure-u-1 pure-u-md-1-5">
         <div class="h-box">
         <% rvs.each do |rv| %>


### PR DESCRIPTION
Currently pulling Reddit comments takes the longest amount of time when rendering the `/watch` page. Moving comments into a separate requests bumps down the time for `/watch` pages significantly. Also provides an easy endpoint for implementing #1.

A user can request Reddit comments for a video by asking `/comments/:id?source=reddit`. If multiple threads exist for a given video, the one with the highest score will be selected. Currently returns thread information and thread comments formatted in the way they are used on the `/watch` page.