### PR TITLE
Change default account type to Invidious accounts

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -1027,7 +1027,7 @@ get "/login" do |env|
   referer ||= "/feed/subscriptions"
 
   account_type = env.params.query["type"]?
-  account_type ||= "google"
+  account_type ||= "invidious"
 
   if account_type == "invidious"
     captcha = generate_captcha(HMAC_KEY)
@@ -1144,7 +1144,7 @@ post "/login" do |env|
           end
 
           if !tfa_code
-            next env.redirect "/login?tfa=true"
+            next env.redirect "/login?tfa=true&type=google"
           end
 
           tl = challenge_results[1][2]

--- a/src/invidious/views/login.ecr
+++ b/src/invidious/views/login.ecr
@@ -8,31 +8,14 @@
         <div class="h-box">
             <div class="pure-g">
                 <div class="pure-u-1-2">
-                    <a class="pure-button <% if account_type == "google" %>pure-button-disabled<% end %>" href="/login">Login to Google</a>
+                    <a class="pure-button <% if account_type == "invidious" %>pure-button-disabled<% end %>" href="/login">Login/Register</a>
                 </div>
                 <div class="pure-u-1-2">
-                    <a class="pure-button <% if account_type == "invidious" %>pure-button-disabled<% end %>" href="/login?type=invidious">Login/Register</a>
+                    <a class="pure-button <% if account_type == "google" %>pure-button-disabled<% end %>" href="/login?type=google">Login to Google</a>
                 </div>
             </div>
             <hr>
-            <% if account_type == "google" %>
-            <form class="pure-form pure-form-stacked" action="/login?referer=<%= referer %>" method="post">
-                <fieldset>
-                    <label for="email">Email:</label>
-                    <input required class="pure-input-1" name="email" type="email" placeholder="Email">
-
-                    <label for="password">Password:</label>
-                    <input required class="pure-input-1" name="password" type="password" placeholder="Password">
-                    
-                    <% if tfa %>
-                    <label for="tfa">Google verification code:</label>
-                    <input required class="pure-input-1" name="tfa" type="text" placeholder="Google verification code">
-                    <% end %>
-
-                    <button type="submit" class="pure-button pure-button-primary">Sign in</button>
-                </fieldset>
-            </form>
-            <% elsif account_type == "invidious" %>
+            <% if account_type == "invidious" %>
             <form class="pure-form pure-form-stacked" action="/login?referer=<%= referer %>&type=invidious" method="post">
                 <fieldset>
                     <label for="email">User ID:</label>
@@ -48,6 +31,23 @@
 
                     <button type="submit" name="action" value="signin" class="pure-button pure-button-primary">Sign In</button>
                     <button type="submit" name="action" value="register" class="pure-button pure-button-primary">Register</button>
+                </fieldset>
+            </form>
+            <% elsif account_type == "google" %>
+            <form class="pure-form pure-form-stacked" action="/login?referer=<%= referer %>" method="post">
+                <fieldset>
+                    <label for="email">Email:</label>
+                    <input required class="pure-input-1" name="email" type="email" placeholder="Email">
+
+                    <label for="password">Password:</label>
+                    <input required class="pure-input-1" name="password" type="password" placeholder="Password">
+                    
+                    <% if tfa %>
+                    <label for="tfa">Google verification code:</label>
+                    <input required class="pure-input-1" name="tfa" type="text" placeholder="Google verification code">
+                    <% end %>
+
+                    <button type="submit" class="pure-button pure-button-primary">Sign in</button>
                 </fieldset>
             </form>
             <% end %>


### PR DESCRIPTION
There's been some confusion on how to login to the site, with people creating an account and not realizing the default is to login with Google (see [here](https://www.reddit.com/r/programming/comments/91i0mc/youtube_page_load_is_5x_slower_in_firefox_and/e30g51l/?context=3)), and several others asking why it is not using OAuth (see [here](https://github.com/omarroth/invidious/issues/31) and [here](https://www.reddit.com/r/programming/comments/91i0mc/youtube_page_load_is_5x_slower_in_firefox_and/e2z5fhq/?context=3)). Although Invidious logs in the same way as a browser, it is bad practice to train users to trust a service that doesn't use OAuth (the reason why it doesn't is explained [here](https://www.reddit.com/r/SideProject/comments/8wvazc/invidous_alternative_frontend_to_youtube/e1zygk2/)).

The default should be to encourage a user to make a new account, and then making it easy to import their subscriptions/preferences from other services (see #21), rather than importing their account directly.