### PR TITLE
Add watch history

### DIFF
--- a/config/sql/users.sql
+++ b/config/sql/users.sql
@@ -12,6 +12,7 @@ CREATE TABLE public.users
     preferences text COLLATE pg_catalog."default",
     password text COLLATE pg_catalog."default",
     token text COLLATE pg_catalog."default",
+    watched text[] COLLATE pg_catalog."default",
     CONSTRAINT users_email_key UNIQUE (email),
     CONSTRAINT users_id_key UNIQUE (id)
 )

--- a/src/invidious/helpers.cr
+++ b/src/invidious/helpers.cr
@@ -29,6 +29,7 @@ DEFAULT_USER_PREFERENCES = Preferences.from_json({
   "max_results" => 40,
   "sort"        => "published",
   "latest_only" => false,
+  "unseen_only" => false,
 }.to_json)
 
 class Config
@@ -147,6 +148,10 @@ class User
     },
     password: String?,
     token:    String,
+    watched:  {
+      type:    Array(String),
+      default: ["N/A"],
+    },
   })
 end
 
@@ -177,6 +182,7 @@ class Preferences
     max_results: Int32,
     sort:        String,
     latest_only: Bool,
+    unseen_only: Bool,
   })
 end
 
@@ -817,7 +823,12 @@ def get_user(sid, client, headers, db, refresh = true)
 
     if refresh && Time.now - user.updated > 1.minute
       user = fetch_user(sid, client, headers, db)
-      user_array = user.to_a
+      if user.watched = ["N/A"]
+        user_array = user.to_a[0..-2]
+      else
+        user_array = user.to_a
+      end
+
       user_array[5] = user_array[5].to_json
       args = arg_array(user_array)
 
@@ -826,7 +837,12 @@ def get_user(sid, client, headers, db, refresh = true)
     end
   else
     user = fetch_user(sid, client, headers, db)
-    user_array = user.to_a
+    if user.watched = ["N/A"]
+      user_array = user.to_a[0..-2]
+    else
+      user_array = user.to_a
+    end
+
     user_array[5] = user_array[5].to_json
     args = arg_array(user.to_a)
 
@@ -864,7 +880,7 @@ def fetch_user(sid, client, headers, db)
 
   token = Base64.encode(Random::Secure.random_bytes(32))
 
-  user = User.new(sid, Time.now, [] of String, channels, email, DEFAULT_USER_PREFERENCES, nil, token)
+  user = User.new(sid, Time.now, [] of String, channels, email, DEFAULT_USER_PREFERENCES, nil, token, [] of String)
   return user
 end
 
@@ -872,7 +888,7 @@ def create_user(sid, email, password)
   password = Crypto::Bcrypt::Password.create(password, cost: 10)
   token = Base64.encode(Random::Secure.random_bytes(32))
 
-  user = User.new(sid, Time.now, [] of String, [] of String, email, DEFAULT_USER_PREFERENCES, password.to_s, token)
+  user = User.new(sid, Time.now, [] of String, [] of String, email, DEFAULT_USER_PREFERENCES, password.to_s, token, [] of String)
 
   return user
 end

--- a/src/invidious/views/preferences.ecr
+++ b/src/invidious/views/preferences.ecr
@@ -88,8 +88,20 @@ function update_value(element) {
             </div>
 
             <div class="pure-control-group">
-                <label for="latest_only">Only show latest video from channel: </label>
+                <label for="latest_only">Only show latest <% if user.preferences.unseen_only %>unseen<% end %> video from channel: </label>
                 <input name="latest_only" id="latest_only" type="checkbox" <% if user.preferences.latest_only %>checked<% end %>>
+            </div>
+
+            <div class="pure-control-group">
+                <label for="unseen_only">Only show unseen: </label>
+                <input name="unseen_only" id="unseen_only" type="checkbox" <% if user.preferences.unseen_only %>checked<% end %>>
+            </div>
+
+            <legend>Data preferences</legend>
+            <div class="pure-control-group">
+                <label>
+                    <a href="/clear_watch_history">Clear watch history</a>
+                </labe>
             </div>
 
             <div class="pure-controls">


### PR DESCRIPTION
Closes #40

Adds an option in user preferences to show only unseen videos in feed. If it and `latest_only` are checked, then it will show only the latest unseen video for each channel. There is also a `clear browsing history` option, which is fairly self-explanatory.

A video is added to a user's watch history if they click on it.