### PR TITLE
Add share button and markers

### DIFF
--- a/src/invidious/helpers.cr
+++ b/src/invidious/helpers.cr
@@ -891,16 +891,16 @@ def decode_time(string)
   time = string.try &.to_f?
 
   if !time
-    hours = /(?<hours>\d+)h/.match(string).try &.["hours"].try &.to_i
+    hours = /(?<hours>\d+)h/.match(string).try &.["hours"].try &.to_f
     hours ||= 0
 
-    minutes = /(?<minutes>\d+)m(?!s)/.match(string).try &.["minutes"].try &.to_i
+    minutes = /(?<minutes>\d+)m(?!s)/.match(string).try &.["minutes"].try &.to_f
     minutes ||= 0
 
-    seconds = /(?<seconds>\d+)s/.match(string).try &.["seconds"].try &.to_i
+    seconds = /(?<seconds>\d+)s/.match(string).try &.["seconds"].try &.to_f
     seconds ||= 0
 
-    millis = /(?<millis>\d+)ms/.match(string).try &.["millis"].try &.to_i
+    millis = /(?<millis>\d+)ms/.match(string).try &.["millis"].try &.to_f
     millis ||= 0
 
     time = hours * 3600 + minutes * 60 + seconds + millis / 1000
@@ -909,10 +909,12 @@ def decode_time(string)
   return time
 end
 
-def decode_date(date : String)
+def decode_date(string : String)
   # Time matches format "20 hours ago", "40 minutes ago"...
-  delta = date.split(" ")[0].to_i
-  case date
+  date = string.split(" ")[-3, 3]
+  delta = date[0].to_i
+
+  case date[1]
   when .includes? "minute"
     delta = delta.minutes
   when .includes? "hour"
@@ -926,7 +928,7 @@ def decode_date(date : String)
   when .includes? "year"
     delta = delta.years
   else
-    raise "Could not parse #{date}"
+    raise "Could not parse #{string}"
   end
 
   return Time.now - delta

--- a/src/invidious/views/embed.ecr
+++ b/src/invidious/views/embed.ecr
@@ -8,10 +8,12 @@
 <link rel="stylesheet" href="https://unpkg.com/video.js@6.10.3/dist/video-js.min.css">
 <link rel="stylesheet" href="https://unpkg.com/silvermine-videojs-quality-selector@1.1.2/dist/css/quality-selector.css">
 <link rel="stylesheet" href="https://unpkg.com/videojs-markers@1.0.1/dist/videojs.markers.min.css">
+<link rel="stylesheet" href="https://unpkg.com/videojs-share@1.1.0/dist/videojs-share.css">
 <script src="https://unpkg.com/video.js@6.10.3/dist/video.min.js"></script>
 <script src="https://unpkg.com/videojs-hotkeys@0.2.21/videojs.hotkeys.min.js"></script>
 <script src="https://unpkg.com/silvermine-videojs-quality-selector@1.1.2/dist/js/silvermine-videojs-quality-selector.min.js"></script>
 <script src="https://unpkg.com/videojs-markers@1.0.1/dist/videojs-markers.min.js"></script>
+<script src="https://unpkg.com/videojs-share@1.1.0/dist/videojs-share.min.js"></script>
 <title><%= video.title %> - Invidious</title>
 </head>
 
@@ -76,6 +78,15 @@ var options = {
    },
 };
 
+var shareOptions = {
+  socials: ["fb", "tw", "reddit", "mail"],
+
+  url: "<%= host_url %>/<%= video.id %>?<%= host_params %>",
+  title: "<%= video.title %>",
+  description: "<%= description %>",
+  image: '<%= thumbnail %>'
+};
+
 var player = videojs('player', options, function() {
     this.hotkeys({
     volumeStep: 0.1,
@@ -116,6 +127,8 @@ var player = videojs('player', options, function() {
     }
   });
 });
+
+player.share(shareOptions);
 
 <% if video_start > 0 || video_end > 0 %>
 player.markers({

--- a/src/invidious/views/embed.ecr
+++ b/src/invidious/views/embed.ecr
@@ -7,10 +7,11 @@
 <meta name="thumbnail" content="<%= thumbnail %>">
 <link rel="stylesheet" href="https://unpkg.com/video.js@6.10.3/dist/video-js.min.css">
 <link rel="stylesheet" href="https://unpkg.com/silvermine-videojs-quality-selector@1.1.2/dist/css/quality-selector.css">
+<link rel="stylesheet" href="https://unpkg.com/videojs-markers@1.0.1/dist/videojs.markers.min.css">
 <script src="https://unpkg.com/video.js@6.10.3/dist/video.min.js"></script>
 <script src="https://unpkg.com/videojs-hotkeys@0.2.21/videojs.hotkeys.min.js"></script>
 <script src="https://unpkg.com/silvermine-videojs-quality-selector@1.1.2/dist/js/silvermine-videojs-quality-selector.min.js"></script>
-<script src="https://unpkg.com/videojs-offset@2.0.0-beta.2/dist/videojs-offset.min.js"></script>
+<script src="https://unpkg.com/videojs-markers@1.0.1/dist/videojs-markers.min.js"></script>
 <title><%= video.title %> - Invidious</title>
 </head>
 
@@ -29,23 +30,31 @@ video, #my_video, .video-js, .vjs-default-skin
 }
 </style>
 
+<% if hlsvp %>
+<script src="https://unpkg.com/videojs-contrib-hls@5.14.1/dist/videojs-contrib-hls.min.js"></script>
+<% end %>
+
 <video playsinline poster="<%= thumbnail %>" title="<%= HTML.escape(video.title) %>" id="player" 
-    <% if autoplay == 1 %>autoplay<% end %>
-    <% if controls == 1 %>controls<% end %>
-    <% if video_loop == 1 %>loop<% end %>
+    <% if autoplay %>autoplay<% end %>
+    <% if controls %>controls<% end %>
+    <% if video_loop %>loop<% end %>
     class="video-js vjs-default-skin">
-    <% if listen %>
-        <% audio_streams.each_with_index do |fmt, i| %>
-            <source src="<%= fmt["url"] %>" type='<%= fmt["type"] %>' label="<%= fmt["bitrate"] %>k" selected="<%= i == 0 ? true : false %>">
-        <% end %>
+    <% if hlsvp %>
+        <source src="<%= hlsvp %>" type="application/x-mpegURL">
     <% else %>
-        <% fmt_stream.each_with_index do |fmt, i| %>
-            <% if quality != "hd720" %>
-            <source src="<%= fmt["url"] %>" type='<%= fmt["type"] %>' label="<%= fmt["label"] %>" selected="<%= quality == fmt["label"].split(" - ")[0] %>">
-            <% else %>
-            <source src="<%= fmt["url"] %>" type='<%= fmt["type"] %>' label="<%= fmt["label"] %>" selected="<%= i == 0 ? true : false %>">
+        <% if listen %>
+            <% audio_streams.each_with_index do |fmt, i| %>
+                <source src="<%= fmt["url"] %>" type='<%= fmt["type"] %>' label="<%= fmt["bitrate"] %>k" selected="<%= i == 0 ? true : false %>">
             <% end %>
-        <% end %>    
+        <% else %>
+            <% fmt_stream.each_with_index do |fmt, i| %>
+                <% if quality != "hd720" %>
+                <source src="<%= fmt["url"] %>" type='<%= fmt["type"] %>' label="<%= fmt["label"] %>" selected="<%= quality == fmt["label"].split(" - ")[0] %>">
+                <% else %>
+                <source src="<%= fmt["url"] %>" type='<%= fmt["type"] %>' label="<%= fmt["label"] %>" selected="<%= i == 0 ? true : false %>">
+                <% end %>
+            <% end %>    
+        <% end %>
     <% end %>
 </video>
 
@@ -59,18 +68,19 @@ var options = {
          'volumePanel',
          'progressControl',
          'remainingTimeDisplay',
+         'captionsButton',
          'qualitySelector',
          'playbackRateMenuButton',
          'fullscreenToggle',
       ],
    },
 };
+
 var player = videojs('player', options, function() {
     this.hotkeys({
     volumeStep: 0.1,
     seekStep: 5,
     enableModifiersForNumbers: false,
-    enableVolumeScroll: false,
     customKeys: {
         play: {
             key: function(e) {
@@ -107,10 +117,29 @@ var player = videojs('player', options, function() {
   });
 });
 
-player.offset({
-  start: <%= video_start %>,
-  end: <%= video_end %>
+<% if video_start > 0 || video_end > 0 %>
+player.markers({
+    onMarkerReached: function(marker) {
+        if (marker.text === 'End') {
+            if (player.loop()) {
+                player.markers.prev('Start');
+            } else {
+                player.pause();
+            }
+        }
+    },
+    markers: [
+        {time: <%= video_start %>, text: 'Start'},
+        <% if video_end < 0 %>
+        {time: <%= video.info["length_seconds"].to_f - 0.5 %>, text: 'End'}
+        <% else %>
+        {time: <%= video_end %>, text: 'End'}
+        <% end %>
+    ]
 });
+
+player.currentTime(<%= video_start %>);
+<% end %>
 
 <% if !listen %>
 var currentSources = player.currentSources();

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -24,10 +24,11 @@
 <meta name="twitter:player:height" content="720">
 <link rel="stylesheet" href="https://unpkg.com/video.js@6.10.3/dist/video-js.min.css">
 <link rel="stylesheet" href="https://unpkg.com/silvermine-videojs-quality-selector@1.1.2/dist/css/quality-selector.css">
+<link rel="stylesheet" href="https://unpkg.com/videojs-markers@1.0.1/dist/videojs.markers.min.css">
 <script src="https://unpkg.com/video.js@6.10.3/dist/video.min.js"></script>
 <script src="https://unpkg.com/videojs-hotkeys@0.2.21/videojs.hotkeys.min.js"></script>
 <script src="https://unpkg.com/silvermine-videojs-quality-selector@1.1.2/dist/js/silvermine-videojs-quality-selector.min.js"></script>
-<script src="https://unpkg.com/videojs-offset@2.0.0-beta.2/dist/videojs-offset.min.js"></script>
+<script src="https://unpkg.com/videojs-markers@1.0.1/dist/videojs-markers.min.js"></script>
 <title><%= video.title %> - Invidious</title>
 <% end %>
 
@@ -130,10 +131,30 @@ var player = videojs('player', options, function() {
 player.volume(<%= preferences.volume.to_f / 100 %>);
 player.playbackRate(<%= preferences.speed %>);
 <% end %>
-player.offset({
-  start: <%= video_start %>,
-  end: <%= video_end %>
+
+<% if video_start > 0 || video_end > 0 %>
+player.markers({
+    onMarkerReached: function(marker) {
+        if (marker.text === 'End') {
+            if (player.loop()) {
+                player.markers.prev('Start');
+            } else {
+                player.pause();
+            }
+        }
+    },
+    markers: [
+        {time: <%= video_start %>, text: 'Start'},
+        <% if video_end < 0 %>
+        {time: <%= video.info["length_seconds"].to_f - 0.5 %>, text: 'End'}
+        <% else %>
+        {time: <%= video_end %>, text: 'End'}
+        <% end %>
+    ]
 });
+
+player.currentTime(<%= video_start %>);
+<% end %>
 
 <% if !listen %>
 var currentSources = player.currentSources();

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -25,10 +25,12 @@
 <link rel="stylesheet" href="https://unpkg.com/video.js@6.10.3/dist/video-js.min.css">
 <link rel="stylesheet" href="https://unpkg.com/silvermine-videojs-quality-selector@1.1.2/dist/css/quality-selector.css">
 <link rel="stylesheet" href="https://unpkg.com/videojs-markers@1.0.1/dist/videojs.markers.min.css">
+<link rel="stylesheet" href="https://unpkg.com/videojs-share@1.1.0/dist/videojs-share.css">
 <script src="https://unpkg.com/video.js@6.10.3/dist/video.min.js"></script>
 <script src="https://unpkg.com/videojs-hotkeys@0.2.21/videojs.hotkeys.min.js"></script>
 <script src="https://unpkg.com/silvermine-videojs-quality-selector@1.1.2/dist/js/silvermine-videojs-quality-selector.min.js"></script>
 <script src="https://unpkg.com/videojs-markers@1.0.1/dist/videojs-markers.min.js"></script>
+<script src="https://unpkg.com/videojs-share@1.1.0/dist/videojs-share.min.js"></script>
 <title><%= video.title %> - Invidious</title>
 <% end %>
 
@@ -86,6 +88,15 @@ var options = {
    },
 };
 
+var shareOptions = {
+  socials: ["fb", "tw", "reddit", "mail"],
+
+  url: "<%= host_url %>/<%= video.id %>?<%= host_params %>",
+  title: "<%= video.title %>",
+  description: "<%= description %>",
+  image: '<%= thumbnail %>'
+};
+
 var player = videojs('player', options, function() {
     this.hotkeys({
     volumeStep: 0.1,
@@ -126,6 +137,8 @@ var player = videojs('player', options, function() {
     }
   });
 });
+
+player.share(shareOptions);
 
 <% if preferences %>
 player.volume(<%= preferences.volume.to_f / 100 %>);


### PR DESCRIPTION
Closes #39 

Fixes `&loop` for videos, also properly converts `\d+h\d+m..` times.
Uses [videojs-markers](https://github.com/spchuang/videojs-markers) to properly show start and end points for videos. Looping on videos with start and end times will only loop the desired section. Either `start` or `end` can also be ommitted to signify from `start` to the end of the video, or from the start of the video to the desired `end`.

Adds a `share` button in the bottom-right for embedded and `/watch` videos which links to a shortened `invidio.us/:id` link.

Also adds share options for Facebook, Twitter, and Reddit thanks to the [videojs-share](https://github.com/mkhazov/videojs-share) extension.

Example of new functionality (markers and share button) looks like this:
![player](https://user-images.githubusercontent.com/14208607/43480326-9295c462-94c8-11e8-8b11-fdc166b6b35a.png)
