### PR TITLE
Make progress colors solid

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -168,7 +168,7 @@ div {
 }
 
 .video-js .vjs-play-progress {
-  background-color: rgba(0, 182, 240, 0.5);
+  background-color: rgba(0, 182, 240, 1);
 }
 
 /* Big "Play" Button */

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -159,7 +159,7 @@ div {
 
 .video-js .vjs-load-progress,
 .video-js .vjs-load-progress div {
-  background: rgba(87, 87, 88, 0.5);
+  background: rgba(87, 87, 88, 1);
 }
 
 .video-js .vjs-slider:hover,


### PR DESCRIPTION
I'm not sure about that, but probably load-progress should has solid color too.
```
.video-js .vjs-load-progress,
.video-js .vjs-load-progress div {
  background: rgba(87, 87, 88, 1);
}
```