### PR TITLE
update readme for required ubuntu dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ crystal build src/invidious.cr --release
 # Install dependencies
 $ curl -sSL https://dist.crystal-lang.org/apt/setup.sh | sudo bash
 $ sudo apt update
-$ sudo apt install crystal libssl-dev libxml2-dev libyaml-dev libgmp-dev libreadline-dev librsvg2-dev postgresql imagemagick
+$ sudo apt install crystal libssl-dev libxml2-dev libyaml-dev libgmp-dev libreadline-dev librsvg2-dev postgresql imagemagick libsqlite3-dev
 
 # Setup PostgreSQL
 $ sudo systemctl enable postgresql


### PR DESCRIPTION
Simple docs update

Testing on Ubuntu 18, without this dev package for sqlite3, you get this error while compiling:
```
$ crystal build src/invidious.cr --release
/usr/bin/ld: cannot find -lsqlite3 (this usually means you need to install the development package for libsqlite3)
collect2: error: ld returned 1 exit status
Error: execution of command failed with code: 1: `cc "${@}" -o '/home/adam/invidious/invidious'  -rdynamic  -lyaml -lxml2 -lsqlite3 -lz `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'` `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'` -lpcre -lm -lgc -lpthread /usr/share/crystal/src/ext/libcrystal.a -levent -lrt -ldl -L/usr/lib -L/usr/local/lib`
```

Installing this dependency resolves this issue