### PR TITLE
Add alternate link with rss feed to playlist page

### DIFF
--- a/src/invidious/views/playlist.ecr
+++ b/src/invidious/views/playlist.ecr
@@ -1,5 +1,6 @@
 <% content_for "header" do %>
 <title><%= playlist.title %> - Invidious</title>
+<link rel="alternate" type="application/rss+xml" title="RSS" href="/feed/playlist/<%= plid %>" />
 <% end %>
 
 <div class="pure-g h-box">


### PR DESCRIPTION
Palemoon and old versions of firefox show feed icon in url bar (see img, right side) if there is `<link rel="alternate" type="application/rss+xml"`
http://i.imgur.com/DW5ygKC.png
This makes more convenient to get playlist feed link.

I didn't compile/deploy invidious in my pc, so I didn't test it. So feel free to edit this PR.

Offtopic: project is amazing! Keep up good work.