### PR TITLE
docker: fix port forwarding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       dockerfile: docker/Dockerfile
     restart: unless-stopped
     ports:
-      - "127.0.0.1:3000:3000"
+      - "3000:3000"
     depends_on:
       - postgres
 


### PR DESCRIPTION
Previous version resulted in ERR_CONNECTION_REFUSED.