### PR TITLE
Change font family to better native selection

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -1,3 +1,8 @@
+html,
+body {
+  font-family: BlinkMacSystemFont,-apple-system,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+}
+
 .deleted {
   background-color: rgb(255, 0, 0, 0.5);
 }
@@ -113,7 +118,6 @@ img.thumbnail {
   border-radius: 2px;
   padding: 2px;
   font-size: 16px;
-  font-family: sans-serif;
   right: 0.25em;
   bottom: -0.75em;
 }
@@ -126,7 +130,6 @@ img.thumbnail {
   border-radius: 2px;
   padding: 4px 8px 4px 8px;
   font-size: 16px;
-  font-family: sans-serif;
   left: 0.2em;
   top: -0.7em;
 }


### PR DESCRIPTION
This set the used font to a better native selection. No font needs to be downloaded. The rendered font will depend on the browser and platform.