### PR TITLE
docker: use alpine:edge base image for building

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest AS builder
+FROM alpine:edge AS builder
 RUN apk add -u crystal shards libc-dev \
     yaml-dev libxml2-dev sqlite-dev sqlite-static zlib-dev openssl-dev
 WORKDIR /invidious


### PR DESCRIPTION
This fixes currently failing Docker builds.
kemalcr/kemal in version 0.26.0 requires Crystal 0.30.0 which is not
yet available on Alpine 3.10 (previously used as the Docker base image).