### PR TITLE
travis: unshallowly clone Git repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ dist: bionic
 jobs:
   include:
     - stage: build
+      # TODO: Shallowly clone again once the .git folder is no longer required for building
+      git:
+        depth: false
       language: crystal
       crystal: latest
       before_install:
@@ -15,6 +18,9 @@ jobs:
         - crystal spec
 
     - stage: build_docker
+      # TODO: Shallowly clone again once the .git folder is no longer required for building
+      git:
+        depth: false
       language: minimal
       services:
         - docker


### PR DESCRIPTION
This fixes a compilation error if too many commits were made after the
most recent tag:

    fatal: No names found, cannot describe anything.
    In src/invidious.cr:60:19
      60 | CURRENT_VERSION = {{ "#{`git describe --tags --abbrev=0`.strip}" }}
    Error: expanding macro

See https://travis-ci.org/leonklingele/invidious/jobs/588672881#L275-L290.