### PR TITLE
Add protocol to the cryptocurrencies

### DIFF
--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -117,11 +117,11 @@
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
                         <i class="icon ion-logo-bitcoin"></i>
-                        BTC: 356DpZyMXu6rYd55Yqzjs29n79kGKWcYrY
+                        BTC: <href="bitcoin:356DpZyMXu6rYd55Yqzjs29n79kGKWcYrY">356DpZyMXu6rYd55Yqzjs29n79kGKWcYrY</href>
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
                         <i class="icon ion-logo-bitcoin"></i>
-                        BCH: qq4ptclkzej5eza6a50et5ggc58hxsq5aylqut2npk
+                        BCH: <href="bitcoincash:qq4ptclkzej5eza6a50et5ggc58hxsq5aylqut2npk">qq4ptclkzej5eza6a50et5ggc58hxsq5aylqut2npk</href>
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
                         <i class="icon ion-logo-usd"></i>


### PR DESCRIPTION
Most if not all cryptocurrency wallets handle the protocol associated to the cryptocurrency they support.

This is why I think it might be a good idea to use the protocol associated to the cryptocurrencies used for Invidious.

This PR should (hopefully) do this.