### PR TITLE
Remove duplicated Github logo on footer

### DIFF
--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -140,9 +140,7 @@
                     </div>
                     <div class="pure-u-1 pure-u-md-1-3">
                         <i class="icon ion-logo-github"></i>
-                        <%= translate(locale, "Current version: ") %> <%= CURRENT_VERSION %>-<%= CURRENT_COMMIT %>
-                        <i>@</i>
-                        <%= CURRENT_BRANCH %>
+                        <%= translate(locale, "Current version: ") %> <%= CURRENT_VERSION %>-<%= CURRENT_COMMIT %> @ <%= CURRENT_BRANCH %>
                     </div>
                 </div>
             </div>

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -141,7 +141,7 @@
                     <div class="pure-u-1 pure-u-md-1-3">
                         <i class="icon ion-logo-github"></i>
                         <%= translate(locale, "Current version: ") %> <%= CURRENT_VERSION %>-<%= CURRENT_COMMIT %>
-                        <i class="icon ion-logo-github"></i>
+                        <i>@</i>
                         <%= CURRENT_BRANCH %>
                     </div>
                 </div>


### PR DESCRIPTION
This Patch will replace the duplicated Github logo with an @ symbol

Like this:
`Current version: 0.20.1-588fc6d @ master`