### PR TITLE
Remove invalid and useless HTML from embed player

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -35,7 +35,7 @@ var shareOptions = {
     title: player_data.title,
     description: player_data.description,
     image: player_data.thumbnail,
-    embedCode: "<iframe id='ivplayer' type='text/html' width='640' height='360' src='" + embed_url + "' style='border:none;'></iframe>"
+    embedCode: "<iframe id='ivplayer' width='640' height='360' src='" + embed_url + "' style='border:none;'></iframe>"
 }
 
 var player = videojs('player', options);


### PR DESCRIPTION
Sorry, I forgot to do that on #975 

The removed code is useless and non-standard (see https://stackoverflow.com/questions/4800227/why-did-youtube-put-a-type-attribute-in-iframe-for-embedded-video)