### PR TITLE
docker: allow to configure Invidious by env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,20 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:3000:3000"
+    environment:
+      # Adapted from ./config/config.yml
+      INVIDIOUS_CONFIG: |
+        channel_threads: 1
+        feed_threads: 1
+        db:
+          user: kemal
+          password: kemal
+          host: postgres
+          port: 5432
+          dbname: invidious
+        full_refresh: false
+        https_only: false
+        domain:
     depends_on:
       - postgres
 


### PR DESCRIPTION
Invidious gained support to read its configuration from an env var
instead of config file in e3c10d779d315adc630e08005b6bdbdce32f7446.

Unfortunately, Docker doesn't allow newline characters in env var
values (see [0]) which means we can only provide a proper YAML config
by using the inlined configuration in docker-compose.yml which,
unfortunately, is tracked by Git. Once support for multiline env var
values has been added to Docker, we should migrate and read the config
from a .env file instead (which is not tracked by Git).

[0]: https://github.com/docker/compose/issues/3527