### PR TITLE
Update code formatting for Crystal 0.33.0

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -60,7 +60,7 @@ REQUEST_HEADERS_WHITELIST  = {"accept", "accept-encoding", "cache-control", "con
 RESPONSE_HEADERS_BLACKLIST = {"access-control-allow-origin", "alt-svc", "server"}
 HTTP_CHUNK_SIZE            = 10485760 # ~10MB
 
-CURRENT_BRANCH  = {{ "#{`git branch | sed -n '/\* /s///p'`.strip}" }}
+CURRENT_BRANCH  = {{ "#{`git branch | sed -n '/* /s///p'`.strip}" }}
 CURRENT_COMMIT  = {{ "#{`git rev-list HEAD --max-count=1 --abbrev-commit`.strip}" }}
 CURRENT_VERSION = {{ "#{`git describe --tags --abbrev=0`.strip}" }}
 

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -315,7 +315,7 @@ def get_referer(env, fallback = "/", unroll = true)
   end
 
   referer = referer.full_path
-  referer = "/" + referer.lstrip("\/\\")
+  referer = "/" + referer.lstrip("/\\")
 
   if referer == env.request.path
     referer = fallback


### PR DESCRIPTION
Crystal 0.33.0 introduced some changes to the code formatter.
Run "crystal tool format" so CI doesn't fail anymore.