### PR TITLE
Consistent IDs for info section

### DIFF
--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -165,9 +165,9 @@
                 </form>
             <% end %>
 
-            <p><i class="icon ion-ios-eye"></i> <%= number_with_separator(video.views) %></p>
-            <p><i class="icon ion-ios-thumbs-up"></i> <%= number_with_separator(video.likes) %></p>
-            <p><i class="icon ion-ios-thumbs-down"></i> <%= number_with_separator(video.dislikes) %></p>
+            <p id="views"><i class="icon ion-ios-eye"></i> <%= number_with_separator(video.views) %></p>
+            <p id="likes"><i class="icon ion-ios-thumbs-up"></i> <%= number_with_separator(video.likes) %></p>
+            <p id="dislikes"><i class="icon ion-ios-thumbs-down"></i> <%= number_with_separator(video.dislikes) %></p>
             <p id="genre"><%= translate(locale, "Genre: ") %>
                 <% if video.genre_url.empty? %>
                     <%= video.genre %>


### PR DESCRIPTION
Five of the eight info section stats had HTML IDs, e.g. genre, family_friendly, etc.
However the remaining three stats did not have IDs: views, likes and dislikes. Therefore I have added them so there is a consistent naming of the IDs in the info section.