### PR TITLE
Switch to official crystallang alpine image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ COPY ./src/ ./src/
 # See definition of CURRENT_BRANCH, CURRENT_COMMIT and CURRENT_VERSION.
 COPY ./.git/ ./.git/
 RUN crystal build ./src/invidious.cr \
-    --static --warnings all --error-on-warnings \
+    --static --warnings all \
     --link-flags "-lxml2 -llzma"
 
 FROM alpine:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,5 @@
-FROM alpine:edge AS builder
-RUN apk add --no-cache curl crystal shards libc-dev \
-    yaml-dev libxml2-dev sqlite-dev zlib-dev openssl-dev \
-    yaml-static sqlite-static zlib-static openssl-libs-static
+FROM crystallang/crystal:0.35.0-alpine AS builder
+RUN apk add --no-cache curl sqlite-static
 WORKDIR /invidious
 COPY ./shard.yml ./shard.yml
 RUN shards update && shards install && \


### PR DESCRIPTION
This PR switches to the official crystal docker image which no longer relies on alpines updates.

Currently requires this diff to build until compile warnings are fixed:
```diff
 # See definition of CURRENT_BRANCH, CURRENT_COMMIT and CURRENT_VERSION.
 COPY ./.git/ ./.git/
 RUN crystal build ./src/invidious.cr \
-    --static --warnings all --error-on-warnings \
+    --static --warnings all \
     --link-flags "-lxml2 -llzma"
 
 FROM alpine:latest
```

<details>
<summary>warnings</summary>
 > [builder 8/8] RUN crystal build ./src/invidious.cr     --static --warnings all --error-on-warnings     --link-flags "-lxml2 -llzma":
#22 41.76 In src/invidious/helpers/helpers.cr:127:3
#22 41.76
#22 41.76  127 | yaml_mapping({
#22 41.76        ^
#22 41.76 Warning: expanding macro
#22 41.76
#22 41.76
#22 41.76 There was a problem expanding macro 'yaml_mapping'
#22 41.76
#22 41.76 Called macro defined in src/invidious/helpers/macros.cr:28:1
#22 41.76
#22 41.76  28 | macro yaml_mapping(mapping)
#22 41.76
#22 41.76 Which expanded to:
#22 41.76
#22 41.76     1 |   def initialize(@annotations, @annotations_subscribed, @autoplay, @captions, @comments, @continue, @continue_autoplay, @dark_mode, @latest_only, @listen, @local, @locale, @max_resul
ts, @notifications_only, @player_style, @quality, @default_home, @feed_menu, @related_videos, @sort, @speed, @thin_mode, @unseen_only, @video_loop, @volume)
#22 41.76     2 |   end
#22 41.76     3 |
#22 41.76     4 |   def to_a
#22 41.76     5 |       return [ @annotations, @annotations_subscribed, @autoplay, @captions, @comments, @continue, @continue_autoplay, @dark_mode, @latest_only, @listen, @local, @locale, @max_results
, @notifications_only, @player_style, @quality, @default_home, @feed_menu, @related_videos, @sort, @speed, @thin_mode, @unseen_only, @video_loop, @volume ]
#22 41.76     6 |   end
#22 41.76     7 |
#22 41.76     8 |   def to_tuple
#22 41.76     9 |       return { @annotations, @annotations_subscribed, @autoplay, @captions, @comments, @continue, @continue_autoplay, @dark_mode, @latest_only, @listen, @local, @locale, @max_results
, @notifications_only, @player_style, @quality, @default_home, @feed_menu, @related_videos, @sort, @speed, @thin_mode, @unseen_only, @video_loop, @volume }
#22 41.76    10 |   end
#22 41.76    11 |
#22 41.76  > 12 |   YAML.mapping({annotations: {type: Bool, default: false}, annotations_subscribed: {type: Bool, default: false}, autoplay: {type: Bool, default: false}, captions: {type: Array(String
), default: ["", "", ""], converter: StringToArray}, comments: {type: Array(String), default: ["youtube", ""], converter: StringToArray}, continue: {type: Bool, default: false}, continue_autoplay: {ty
pe: Bool, default: true}, dark_mode: {type: String, default: "", converter: BoolToString}, latest_only: {type: Bool, default: false}, listen: {type: Bool, default: false}, local: {type: Bool, default:
 false}, locale: {type: String, default: "en-US"}, max_results: {type: Int32, default: 40}, notifications_only: {type: Bool, default: false}, player_style: {type: String, default: "invidious"}, qualit
y: {type: String, default: "hd720"}, default_home: {type: String, default: "Popular"}, feed_menu: {type: Array(String), default: ["Popular", "Trending", "Subscriptions", "Playlists"]}, related_videos:
 {type: Bool, default: true}, sort: {type: String, default: "published"}, speed: {type: Float32, default: 1.0_f32}, thin_mode: {type: Bool, default: false}, unseen_only: {type: Bool, default: false},
video_loop: {type: Bool, default: false}, volume: {type: Int32, default: 100}})
#22 41.76 Warning: Deprecated YAML.mapping. use YAML::Serializable instead (the legacy behaviour is also available in a shard at github:crystal-lang/yaml_mapping.cr)
#22 41.76
#22 41.76 In src/invidious/helpers/helpers.cr:233:8
#22 41.76
#22 41.76  233 | YAML.mapping({
#22 41.76             ^------
#22 41.76 Warning: Deprecated YAML.mapping. use YAML::Serializable instead (the legacy behaviour is also available in a shard at github:crystal-lang/yaml_mapping.cr)
#22 41.76
#22 41.76 In src/invidious/comments.cr:2:8
#22 41.76
#22 41.76  2 | JSON.mapping({
#22 41.76           ^------
#22 41.76 Warning: Deprecated JSON.mapping. use JSON::Serializable instead (the legacy behaviour is also available in a shard at github:crystal-lang/json_mapping.cr)
#22 41.76
#22 41.76 In src/invidious/comments.cr:19:8
#22 41.76
#22 41.76  19 | JSON.mapping({
#22 41.76            ^------
#22 41.76 Warning: Deprecated JSON.mapping. use JSON::Serializable instead (the legacy behaviour is also available in a shard at github:crystal-lang/json_mapping.cr)
#22 41.76
#22 41.76 In src/invidious/comments.cr:34:8
#22 41.76
#22 41.76  34 | JSON.mapping({
#22 41.76            ^------
#22 41.76 Warning: Deprecated JSON.mapping. use JSON::Serializable instead (the legacy behaviour is also available in a shard at github:crystal-lang/json_mapping.cr)
#22 41.76
#22 41.76 In src/invidious/comments.cr:46:8
#22 41.76
#22 41.76  46 | JSON.mapping({
#22 41.76            ^------
#22 41.76 Warning: Deprecated JSON.mapping. use JSON::Serializable instead (the legacy behaviour is also available in a shard at github:crystal-lang/json_mapping.cr)
#22 41.76
#22 41.76 In src/invidious/comments.cr:54:8
#22 41.76
#22 41.76  54 | JSON.mapping({
#22 41.76            ^------
#22 41.76 Warning: Deprecated JSON.mapping. use JSON::Serializable instead (the legacy behaviour is also available in a shard at github:crystal-lang/json_mapping.cr)
#22 41.76
#22 41.76 In src/invidious/users.cr:70:3
#22 41.76
#22 41.76  70 | json_mapping({
#22 41.76       ^
#22 41.76 Warning: expanding macro
#22 41.76
#22 41.76
#22 41.76 There was a problem expanding macro 'json_mapping'
#22 41.76
#22 41.76 Called macro defined in src/invidious/helpers/macros.cr:16:1
#22 41.76
#22 41.76  16 | macro json_mapping(mapping)
#22 41.76
#22 41.76 Which expanded to:
#22 41.76
#22 41.76     1 |   def initialize(@annotations, @annotations_subscribed, @autoplay, @captions, @comments, @continue, @continue_autoplay, @dark_mode, @latest_only, @listen, @local, @locale, @max_resul
ts, @notifications_only, @player_style, @quality, @default_home, @feed_menu, @related_videos, @sort, @speed, @thin_mode, @unseen_only, @video_loop, @volume)
#22 41.76     2 |   end
#22 41.76     3 |
#22 41.76     4 |   def to_a
#22 41.76     5 |       return [ @annotations, @annotations_subscribed, @autoplay, @captions, @comments, @continue, @continue_autoplay, @dark_mode, @latest_only, @listen, @local, @locale, @max_results
, @notifications_only, @player_style, @quality, @default_home, @feed_menu, @related_videos, @sort, @speed, @thin_mode, @unseen_only, @video_loop, @volume ]
#22 41.76     6 |   end
#22 41.76     7 |
#22 41.76     8 |   patched_json_mapping( {annotations: {type: Bool, default: CONFIG.default_user_preferences.annotations}, annotations_subscribed: {type: Bool, default: CONFIG.default_user_preference
s.annotations_subscribed}, autoplay: {type: Bool, default: CONFIG.default_user_preferences.autoplay}, captions: {type: Array(String), default: CONFIG.default_user_preferences.captions, converter: Conf
igPreferences::StringToArray}, comments: {type: Array(String), default: CONFIG.default_user_preferences.comments, converter: ConfigPreferences::StringToArray}, continue: {type: Bool, default: CONFIG.d
efault_user_preferences.continue}, continue_autoplay: {type: Bool, default: CONFIG.default_user_preferences.continue_autoplay}, dark_mode: {type: String, default: CONFIG.default_user_preferences.dark_
mode, converter: ConfigPreferences::BoolToString}, latest_only: {type: Bool, default: CONFIG.default_user_preferences.latest_only}, listen: {type: Bool, default: CONFIG.default_user_preferences.listen
}, local: {type: Bool, default: CONFIG.default_user_preferences.local}, locale: {type: String, default: CONFIG.default_user_preferences.locale, converter: ProcessString}, max_results: {type: Int32, de
fault: CONFIG.default_user_preferences.max_results, converter: ClampInt}, notifications_only: {type: Bool, default: CONFIG.default_user_preferences.notifications_only}, player_style: {type: String, de
fault: CONFIG.default_user_preferences.player_style, converter: ProcessString}, quality: {type: String, default: CONFIG.default_user_preferences.quality, converter: ProcessString}, default_home: {type
: String, default: CONFIG.default_user_preferences.default_home}, feed_menu: {type: Array(String), default: CONFIG.default_user_preferences.feed_menu}, related_videos: {type: Bool, default: CONFIG.def
ault_user_preferences.related_videos}, sort: {type: String, default: CONFIG.default_user_preferences.sort, converter: ProcessString}, speed: {type: Float32, default: CONFIG.default_user_preferences.sp
eed}, thin_mode: {type: Bool, default: CONFIG.default_user_preferences.thin_mode}, unseen_only: {type: Bool, default: CONFIG.default_user_preferences.unseen_only}, video_loop: {type: Bool, default: CO
NFIG.default_user_preferences.video_loop}, volume: {type: Int32, default: CONFIG.default_user_preferences.volume}} )
#22 41.76  >  9 |   YAML.mapping( {annotations: {type: Bool, default: CONFIG.default_user_preferences.annotations}, annotations_subscribed: {type: Bool, default: CONFIG.default_user_preferences.annota
tions_subscribed}, autoplay: {type: Bool, default: CONFIG.default_user_preferences.autoplay}, captions: {type: Array(String), default: CONFIG.default_user_preferences.captions, converter: ConfigPrefer
ences::StringToArray}, comments: {type: Array(String), default: CONFIG.default_user_preferences.comments, converter: ConfigPreferences::StringToArray}, continue: {type: Bool, default: CONFIG.default_u
ser_preferences.continue}, continue_autoplay: {type: Bool, default: CONFIG.default_user_preferences.continue_autoplay}, dark_mode: {type: String, default: CONFIG.default_user_preferences.dark_mode, co
nverter: ConfigPreferences::BoolToString}, latest_only: {type: Bool, default: CONFIG.default_user_preferences.latest_only}, listen: {type: Bool, default: CONFIG.default_user_preferences.listen}, local
: {type: Bool, default: CONFIG.default_user_preferences.local}, locale: {type: String, default: CONFIG.default_user_preferences.locale, converter: ProcessString}, max_results: {type: Int32, default: C
ONFIG.default_user_preferences.max_results, converter: ClampInt}, notifications_only: {type: Bool, default: CONFIG.default_user_preferences.notifications_only}, player_style: {type: String, default: C
ONFIG.default_user_preferences.player_style, converter: ProcessString}, quality: {type: String, default: CONFIG.default_user_preferences.quality, converter: ProcessString}, default_home: {type: String
, default: CONFIG.default_user_preferences.default_home}, feed_menu: {type: Array(String), default: CONFIG.default_user_preferences.feed_menu}, related_videos: {type: Bool, default: CONFIG.default_use
r_preferences.related_videos}, sort: {type: String, default: CONFIG.default_user_preferences.sort, converter: ProcessString}, speed: {type: Float32, default: CONFIG.default_user_preferences.speed}, th
in_mode: {type: Bool, default: CONFIG.default_user_preferences.thin_mode}, unseen_only: {type: Bool, default: CONFIG.default_user_preferences.unseen_only}, video_loop: {type: Bool, default: CONFIG.def
ault_user_preferences.video_loop}, volume: {type: Int32, default: CONFIG.default_user_preferences.volume}} )
#22 41.76 Warning: Deprecated YAML.mapping. use YAML::Serializable instead (the legacy behaviour is also available in a shard at github:crystal-lang/yaml_mapping.cr)
#22 41.76
#22 41.76 A total of 8 warnings were found.

</details>

Base Image Dockerfile can be found here https://github.com/crystal-lang/distribution-scripts/blob/master/docker/alpine.Dockerfile

Closes #1245