### PR TITLE
Fix livestream parsing URLs

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -3150,7 +3150,7 @@ get "/api/manifest/hls_playlist/*" do |env|
   manifest = response.body
 
   if local
-    manifest = manifest.gsub(/^https:\/\/r\d---.{11}\.c\.youtube\.com[^\n]*/m) do |match|
+    manifest = manifest.gsub(/^https:\/\/\w+---.{11}\.c\.youtube\.com[^\n]*/m) do |match|
       path = URI.parse(match).path
 
       path = path.lchop("/videoplayback/")


### PR DESCRIPTION
Closes #2352

~~There must be a better regex for future proof that can handle the case where youtube could add a new `r` but I don't have the time right now.~~

~~Please suggest one and I'll try it.~~

Regex101 test case: https://regex101.com/r/OHZpgP/1
And no `/^https:\/\/.+---.{11}\.c\.youtube\.com[^\n]*/m` doesn't work.