### PR TITLE
unfuck playlists

### DIFF
--- a/src/invidious/views/components/item.ecr
+++ b/src/invidious/views/components/item.ecr
@@ -48,7 +48,7 @@
                 <p dir="auto"><b><%= HTML.escape(item.author) %></b></p>
             </a>
         <% when PlaylistVideo %>
-            <a style="width:100%" href="/watch?v=<%= item.id %>&list=<%= item.plid %>">
+            <a style="width:100%" href="/watch?v=<%= item.id %>&list=<%= item.plid %>&index=<%= item.index %>">
                 <% if !env.get("preferences").as(Preferences).thin_mode %>
                     <div class="thumbnail">
                         <img class="thumbnail" src="/vi/<%= item.id %>/mqdefault.jpg"/>


### PR DESCRIPTION
- with the index playlists know where in the playlist they are
- with the old way of shifting out playlists videos the next video is not the always the second video

send the https://github.com/iv-org/invidious/issues/1952 money to bitcoin:1Archive1n2C579dMsAu3iC6tWzuQJz8dN