### PR TITLE
Add border-radius 50% to channel profile class

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -19,6 +19,7 @@ body {
   font-size: 1.17em;
   font-weight: bold;
   vertical-align: middle;
+  border-radius: 50%;
 }
 
 .channel-profile > img {


### PR DESCRIPTION
Since youtube has this too so most pictures are designed to be round. 
I just added border-radius 50% to channel-profile class. 
This looks better in my opinion and I already have it live on my [instance](https://invidio.xamh.de/) if you wanna take a look at it.