### PR TITLE
Fix `Role "kemal" does not exist`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       POSTGRES_PASSWORD: kemal
       POSTGRES_USER: kemal
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER $$POSTGRES_DB"]
   invidious:
     build:
       context: .


### PR DESCRIPTION
Fixes #2485

For some reason, `pg_isready` required a DB name, and by default will try with a database that has the same name as the current user.