### PR TITLE
Fix for #2488 - parse contents of search results of type=Category

### DIFF
--- a/src/invidious/helpers/serialized_yt_data.cr
+++ b/src/invidious/helpers/serialized_yt_data.cr
@@ -237,6 +237,7 @@ class Category
 
   def to_json(locale, json : JSON::Builder)
     json.object do
+      json.field "type", "category"
       json.field "title", self.title
       json.field "contents" do
         json.array do


### PR DESCRIPTION
Fixes #2488

YouTube seems to return an item of type=Category when performing universal (type=all) queries, this item is returned as the last item of the first page of search results. This item type was not handled correctly which made this type of query fail nearly every time.

This patch implements a simple fix in that it parses the content of the Category item, adding the contained items to the search result.