### PR TITLE
Handle missing title fields in VideoRendererParser.parse (fixes #2495)

### DIFF
--- a/src/invidious/helpers/extractors.cr
+++ b/src/invidious/helpers/extractors.cr
@@ -43,7 +43,7 @@ private module Parsers
 
     private def self.parse(item_contents, author_fallback)
       video_id = item_contents["videoId"].as_s
-      title = extract_text(item_contents["title"]) || ""
+      title = extract_text(item_contents["title"]?) || ""
 
       # Extract author information
       if author_info = item_contents.dig?("ownerText", "runs", 0)


### PR DESCRIPTION
Sometimes YouTube does not seem to provide title attributes, this situation needs to be handled everywhere item titles are accessed. This patch just adds an optional (question mark) where one was missing.

Fixes #2495 