### PR TITLE
Workflow: use docker-meta to generate versioned docker tags & OCI compatible labels

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -64,7 +64,7 @@ jobs:
             quay.expires-after=12w
 
       - name: Build and push Docker AMD64 image for Push Event
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/Dockerfile
@@ -90,7 +90,7 @@ jobs:
             quay.expires-after=12w
 
       - name: Build and push Docker ARM64 image for Push Event
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/Dockerfile.arm64


### PR DESCRIPTION
I updated the workflow to have additional tags based on git tags and [OCI compatible labels](https://github.com/opencontainers/image-spec/blob/main/annotations.md).

This way an administrator can get images by Invidious version tag.

Here is an example tag [0.20.4](https://github.com/unbelauscht/invidious/actions/runs/6473340341) and the [resulting images](https://hub.docker.com/r/jan4971/invidious/tags).