### PR TITLE
Overhaul VideoJS dependency manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /invidious
 /sentry
 /config/config.yml
+/invidious-videojs-dep-install

--- a/scripts/fetch-player-dependencies.cr
+++ b/scripts/fetch-player-dependencies.cr
@@ -72,6 +72,7 @@ class PlayerDependenciesConfig
   include YAML::Serializable
 
   property version : String
+  property registry_url : String
   property dependencies : Hash(YAML::Any, ConfigDependency)
 
   def get_dependencies_to_fetch
@@ -131,7 +132,7 @@ class Dependency
       Dir.mkdir(@download_path)
     end
 
-    HTTP::Client.get("https://registry.npmjs.org/#{@dependency}/-/#{@dependency}-#{@config.version}.tgz") do |response|
+    HTTP::Client.get("#{CONFIG.dependency_config.registry_url}}/#{@dependency}/-/#{@dependency}-#{@config.version}.tgz") do |response|
       data = response.body_io.gets_to_end
       File.write(downloaded_package_path, data)
       self.validate_checksum(data)

--- a/scripts/fetch-player-dependencies.cr
+++ b/scripts/fetch-player-dependencies.cr
@@ -116,8 +116,11 @@ class Dependency
   end
 
   private def validate_checksum(io)
-    if !CONFIG.skip_checksum && Digest::SHA1.hexdigest(io) != @config.shasum
-      raise IO::Error.new("Checksum for '#{@dependency}' failed")
+    return if CONFIG.skip_checksum
+
+    digest = Digest::SHA1.hexdigest(io)
+    if digest != @config.shasum
+      raise IO::Error.new("Checksum for '#{@dependency}' failed. \"#{digest}\" does not match configured \"#{@config.shasum}\"")
     end
   end
 

--- a/scripts/fetch-player-dependencies.cr
+++ b/scripts/fetch-player-dependencies.cr
@@ -42,14 +42,15 @@ class Dependency
       target_path = sprintf(full_target_path, {"file_extension": ".#{extension}"})
     end
 
+    target_path = Path[target_path]
+
     if download_as = @dependency_config.dig?(YAML::Any.new("install_instructions"), YAML::Any.new("download_as"))
       destination_path = "#{@destination_path}/#{sprintf(download_as.as_s, {"file_extension": ".#{extension}"})}"
     else
-      destination_path = @destination_path
+      destination_path = Path[@destination_path].join(target_path.basename)
     end
 
-    # https://github.com/crystal-lang/crystal/issues/7777
-    `mv #{target_path} #{destination_path}`
+    File.copy(target_path, destination_path)
   end
 
   private def fetch_path(is_css)

--- a/scripts/fetch-player-dependencies.cr
+++ b/scripts/fetch-player-dependencies.cr
@@ -27,7 +27,7 @@ class Dependency
       File.write("#{@download_path}/package.tgz", data)
 
       # https://github.com/iv-org/invidious/pull/2397#issuecomment-922375908
-      if !@skip_checksum && `sha1sum #{@download_path}/package.tgz`.split(" ")[0] != @dependency_config["shasum"]
+      if !@skip_checksum && Digest::SHA1.hexdigest(data) != @dependency_config["shasum"]
         raise Exception.new("Checksum for '#{@dependency}' failed")
       end
     end

--- a/scripts/fetch-player-dependencies.cr
+++ b/scripts/fetch-player-dependencies.cr
@@ -14,6 +14,7 @@ struct InstallInstruction
   property js_path : String? = nil
   property css_path : String? = nil
   property download_as : String? = nil
+  property no_styling : Bool = false
 end
 
 # Object representing a dependency specified within `videojs-dependencies.yml`
@@ -34,15 +35,12 @@ class ConfigDependency
     # Does the directory exist?
     # Does the Javascript file exist?
     # Does the CSS file exist?
-    #
-    # videojs-contrib-quality-levels.js is the only dependency that does not come with a CSS file so
-    # we skip the check there
     if !Dir.exists?(path)
       Dir.mkdir(path)
       return true
     elsif !(File.exists?("#{path}/#{name}.js") || File.exists?("#{path}/versions.yml"))
       return true
-    elsif name != "videojs-contrib-quality-levels" && !File.exists?("#{path}/#{name}.css")
+    elsif !(self.install_instructions.try &.no_styling) && !File.exists?("#{path}/#{name}.css")
       return true
     end
 

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -150,6 +150,7 @@ Invidious::Database.check_integrity(CONFIG)
     potential_arguments = {
       {:minified_player_dependencies, "--minified"},
       {:skip_player_dependencies_checksum, "--skip-checksum"},
+      {:clear_player_dependencies_cache, "--clear-cache"},
     }
   %}
 

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -144,12 +144,25 @@ Invidious::Database.check_integrity(CONFIG)
   # Running the script by itself would show some colorful feedback while this doesn't.
   # Perhaps we should just move the script to runtime in order to get that feedback?
 
-  {% puts "\nChecking player dependencies, this may take more than 20 minutes... If it is stuck, check your internet connection.\n" %}
-  {% if flag?(:minified_player_dependencies) %}
-    {% puts run("../scripts/fetch-player-dependencies.cr", "--minified").stringify %}
-  {% else %}
-    {% puts run("../scripts/fetch-player-dependencies.cr").stringify %}
+  {% fetch_script_arguments = [] of StringLiteral %}
+
+  {%
+    potential_arguments = {
+      {:minified_player_dependencies, "--minified"},
+      {:skip_player_dependencies_checksum, "--skip-checksum"},
+    }
+  %}
+
+  {% for potential_argument in potential_arguments %}
+    {% flag_, script_argument = potential_argument %}
+
+    {% if flag?(flag_) %}
+      {% fetch_script_arguments << script_argument.id %}
+    {% end %}
   {% end %}
+
+  {% puts "\nChecking player dependencies, this may take more than 20 minutes... If it is stuck, check your internet connection.\n" %}
+  {% puts run("../scripts/fetch-player-dependencies.cr", fetch_script_arguments.splat).stringify %}
   {% puts "\nDone checking player dependencies, now compiling Invidious...\n" %}
 {% end %}
 

--- a/src/invidious/views/components/player_sources.ecr
+++ b/src/invidious/views/components/player_sources.ecr
@@ -1,12 +1,12 @@
-<link rel="stylesheet" href="/videojs/video.js/video-js.css?v=<%= ASSET_COMMIT %>">
+<link rel="stylesheet" href="/videojs/video.js/video.js.css?v=<%= ASSET_COMMIT %>">
 <link rel="stylesheet" href="/videojs/videojs-http-source-selector/videojs-http-source-selector.css?v=<%= ASSET_COMMIT %>">
-<link rel="stylesheet" href="/videojs/videojs-markers/videojs.markers.css?v=<%= ASSET_COMMIT %>">
+<link rel="stylesheet" href="/videojs/videojs-markers/videojs-markers.css?v=<%= ASSET_COMMIT %>">
 <link rel="stylesheet" href="/videojs/videojs-share/videojs-share.css?v=<%= ASSET_COMMIT %>">
 <link rel="stylesheet" href="/videojs/videojs-vtt-thumbnails/videojs-vtt-thumbnails.css?v=<%= ASSET_COMMIT %>">
 <link rel="stylesheet" href="/videojs/videojs-mobile-ui/videojs-mobile-ui.css?v=<%= ASSET_COMMIT %>">
 <link rel="stylesheet" href="/css/player.css?v=<%= ASSET_COMMIT %>">
 
-<script src="/videojs/video.js/video.js?v=<%= ASSET_COMMIT %>"></script>
+<script src="/videojs/video.js/video.js.js?v=<%= ASSET_COMMIT %>"></script>
 <script src="/videojs/videojs-mobile-ui/videojs-mobile-ui.js?v=<%= ASSET_COMMIT %>"></script>
 <script src="/videojs/videojs-contrib-quality-levels/videojs-contrib-quality-levels.js?v=<%= ASSET_COMMIT %>"></script>
 <script src="/videojs/videojs-http-source-selector/videojs-http-source-selector.js?v=<%= ASSET_COMMIT %>"></script>

--- a/videojs-dependencies.yml
+++ b/videojs-dependencies.yml
@@ -1,7 +1,14 @@
-# Due to a 'video append of' error (see #3011), we're stuck on 7.12.1.
+#Due to a 'video append of' error (see #3011), we're stuck on 7.12.1.
 video.js:
   version: 7.12.1
   shasum: 1d12eeb1f52e3679e8e4c987d9b9eb37e2247fa2
+  
+  install_instructions:
+    js_path: "dist/video%{file_extension}"
+    css_path: "dist/video-js%{file_extension}"
+
+    # Normalize names to simplify File.exists? check
+    download_as: "video.js%{file_extension}"
 
 videojs-contrib-quality-levels:
   version: 2.1.0
@@ -14,6 +21,10 @@ videojs-http-source-selector:
 videojs-markers:
   version: 1.0.1
   shasum: d7f8d804253fd587813271f8db308a22b9f7df34
+
+  install_instructions:
+    css_path: "dist/videojs.markers%{file_extension}"
+    download_as: "videojs-markers%{file_extension}"
 
 videojs-mobile-ui:
   version: 0.6.1
@@ -38,10 +49,15 @@ videojs-vtt-thumbnails:
 # We're using iv-org's fork of videojs-quality-selector,
 # which isn't published on NPM, and doesn't have any
 # easy way of fetching the compiled variant.
-#
+
 # silvermine-videojs-quality-selector:
 #   version: 1.1.2
 #   shasum: 94033ff9ee52ba6da1263b97c9a74d5b3dfdf711
+
+#   install_instructions:
+#     js_path: "dist/js/silvermine-videojs-quality-selector%{file_extension}"
+#     css_path: "dist/css/quality-selector%{file_extension}"
+#     download_as: silvermine-videojs-quality-selector%{file_extension}
 
 
 # Ditto. Although this extension contains the complied variant in its git repo, 

--- a/videojs-dependencies.yml
+++ b/videojs-dependencies.yml
@@ -21,6 +21,9 @@ dependencies:
     version: 2.1.0
     shasum: 046e9e21ed01043f512b83a1916001d552457083
 
+    install_instructions:
+      no_styling: true
+
   videojs-http-source-selector:
     version: 1.1.6
     shasum: 073aadbea0106ba6c98d6b611094dbf8554ffa1f

--- a/videojs-dependencies.yml
+++ b/videojs-dependencies.yml
@@ -1,4 +1,5 @@
 version: 1
+registry_url: "https://registry.npmjs.org"
 dependencies:
   #Due to a 'video append of' error (see #3011), we're stuck on 7.12.1.
   video.js:

--- a/videojs-dependencies.yml
+++ b/videojs-dependencies.yml
@@ -1,70 +1,72 @@
-#Due to a 'video append of' error (see #3011), we're stuck on 7.12.1.
-video.js:
-  version: 7.12.1
-  shasum: 1d12eeb1f52e3679e8e4c987d9b9eb37e2247fa2
-  
-  install_instructions:
-    js_path: "dist/video%{file_extension}"
-    css_path: "dist/video-js%{file_extension}"
+version: 1
+dependencies:
+  #Due to a 'video append of' error (see #3011), we're stuck on 7.12.1.
+  video.js:
+    version: 7.12.1
+    shasum: 1d12eeb1f52e3679e8e4c987d9b9eb37e2247fa2
 
-    # Normalize names to simplify File.exists? check
-    download_as: "video.js%{file_extension}"
+    install_instructions:
+      js_path: "dist/video%{file_extension}"
+      css_path: "dist/video-js%{file_extension}"
 
-videojs-contrib-quality-levels:
-  version: 2.1.0
-  shasum: 046e9e21ed01043f512b83a1916001d552457083
+      # Normalize names to simplify File.exists? check
+      download_as: "video.js%{file_extension}"
 
-videojs-http-source-selector:
-  version: 1.1.6
-  shasum: 073aadbea0106ba6c98d6b611094dbf8554ffa1f
+  videojs-contrib-quality-levels:
+    version: 2.1.0
+    shasum: 046e9e21ed01043f512b83a1916001d552457083
 
-videojs-markers:
-  version: 1.0.1
-  shasum: d7f8d804253fd587813271f8db308a22b9f7df34
+  videojs-http-source-selector:
+    version: 1.1.6
+    shasum: 073aadbea0106ba6c98d6b611094dbf8554ffa1f
 
-  install_instructions:
-    css_path: "dist/videojs.markers%{file_extension}"
-    download_as: "videojs-markers%{file_extension}"
+  videojs-markers:
+    version: 1.0.1
+    shasum: d7f8d804253fd587813271f8db308a22b9f7df34
 
-videojs-mobile-ui:
-  version: 0.6.1
-  shasum: 0e146c4c481cbee0729cb5e162e558b455562cd0
+    install_instructions:
+      css_path: "dist/videojs.markers%{file_extension}"
+      download_as: "videojs-markers%{file_extension}"
 
-videojs-overlay:
-  version: 2.1.4
-  shasum: 5a103b25374dbb753eb87960d8360c2e8f39cc05
+  videojs-mobile-ui:
+    version: 0.6.1
+    shasum: 0e146c4c481cbee0729cb5e162e558b455562cd0
 
-videojs-share:
-  version: 3.2.1
-  shasum: 0a3024b981387b9d21c058c829760a72c14b8ceb
+  videojs-overlay:
+    version: 2.1.4
+    shasum: 5a103b25374dbb753eb87960d8360c2e8f39cc05
 
-videojs-vr:
-  version: 1.8.0
-  shasum: 7f2f07f760d8a329c615acd316e49da6ee8edd34
+  videojs-share:
+    version: 3.2.1
+    shasum: 0a3024b981387b9d21c058c829760a72c14b8ceb
 
-videojs-vtt-thumbnails:
-  version: 0.0.13
-  shasum: d1e7d47f4ed80bb52f5fc4f4bad4bfc871f5970f
+  videojs-vr:
+    version: 1.8.0
+    shasum: 7f2f07f760d8a329c615acd316e49da6ee8edd34
 
-# We're using iv-org's fork of videojs-quality-selector,
-# which isn't published on NPM, and doesn't have any
-# easy way of fetching the compiled variant.
+  videojs-vtt-thumbnails:
+    version: 0.0.13
+    shasum: d1e7d47f4ed80bb52f5fc4f4bad4bfc871f5970f
 
-# silvermine-videojs-quality-selector:
-#   version: 1.1.2
-#   shasum: 94033ff9ee52ba6da1263b97c9a74d5b3dfdf711
+  # We're using iv-org's fork of videojs-quality-selector,
+  # which isn't published on NPM, and doesn't have any
+  # easy way of fetching the compiled variant.
 
-#   install_instructions:
-#     js_path: "dist/js/silvermine-videojs-quality-selector%{file_extension}"
-#     css_path: "dist/css/quality-selector%{file_extension}"
-#     download_as: silvermine-videojs-quality-selector%{file_extension}
+  # silvermine-videojs-quality-selector:
+  #   version: 1.1.2
+  #   shasum: 94033ff9ee52ba6da1263b97c9a74d5b3dfdf711
+
+  #   install_instructions:
+  #     js_path: "dist/js/silvermine-videojs-quality-selector%{file_extension}"
+  #     css_path: "dist/css/quality-selector%{file_extension}"
+  #     download_as: silvermine-videojs-quality-selector%{file_extension}
 
 
-# Ditto. Although this extension contains the complied variant in its git repo, 
-# it lacks any sort of versioning. As such, the script will ignore it.
-#
-# videojs-youtube-annotations:
-#   github: https://github.com/afrmtbl/videojs-youtube-annotations
+  # Ditto. Although this extension contains the complied variant in its git repo,
+  # it lacks any sort of versioning. As such, the script will ignore it.
+  #
+  # videojs-youtube-annotations:
+  #   github: https://github.com/afrmtbl/videojs-youtube-annotations
 
 
 

--- a/videojs-dependencies.yml
+++ b/videojs-dependencies.yml
@@ -1,5 +1,7 @@
 version: 1
 registry_url: "https://registry.npmjs.org"
+cache_directory: "/tmp/invidious-videojs-dep-install"
+
 dependencies:
   #Due to a 'video append of' error (see #3011), we're stuck on 7.12.1.
   video.js:

--- a/videojs-dependencies.yml
+++ b/videojs-dependencies.yml
@@ -2,7 +2,7 @@ version: 1
 registry_url: "https://registry.npmjs.org"
 
 # Dependencies are stored as <dependency_name>/package.tgz
-cache_directory: "/tmp/invidious-videojs-dep-install"
+cache_directory: "./invidious-videojs-dep-install"
 
 dependencies:
   #Due to a 'video append of' error (see #3011), we're stuck on 7.12.1.

--- a/videojs-dependencies.yml
+++ b/videojs-dependencies.yml
@@ -1,5 +1,7 @@
 version: 1
 registry_url: "https://registry.npmjs.org"
+
+# Dependencies are stored as <dependency_name>/package.tgz
 cache_directory: "/tmp/invidious-videojs-dep-install"
 
 dependencies:


### PR DESCRIPTION
- Refactors code in the script
- Simplify workarounds for dependencies with differing structure
- Adds check for missing dependency files in assets/videojs/* in case of improper installation
- Use native Crystal digest for checksum instead of system command
- Don't clear the cache each time the script is, instead there's the parameter `--clear-cache` or the compile time flag `clear_player_dependencies_cache` when ran through Invidious.
- Changes the default cache directly to be relative to the Invidious repo
- Adds ability to use a custom NPM registry
- Adds ability to change the cache directory
- Allows using pre-existing downloaded tarballs of the dependencies
- Logs checksum when validation fails. 

- Allows skipping checksum with the `--skip-checksum` parameter when calling the script directly, or the `skip_player_dependencies_checksum` compile-time flag when used through Invidious