### PR TITLE
Playlists: fix parsing error when some videos are paid for in a course

### DIFF
--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -438,7 +438,7 @@ def get_playlist_videos(playlist : InvidiousPlaylist | Playlist, offset : Int32,
       # 100 videos per request
       ctoken = produce_playlist_continuation(playlist.id, offset)
       initial_data = YoutubeAPI.browse(ctoken)
-      videos += extract_playlist_videos(initial_data)
+      videos += extract_playlist_videos(playlist.id, initial_data)
 
       offset += 100
     end
@@ -447,7 +447,7 @@ def get_playlist_videos(playlist : InvidiousPlaylist | Playlist, offset : Int32,
   end
 end
 
-def extract_playlist_videos(initial_data : Hash(String, JSON::Any))
+def extract_playlist_videos(playlist_id : String, initial_data : Hash(String, JSON::Any))
   videos = [] of PlaylistVideo | ProblematicTimelineItem
 
   if initial_data["contents"]?
@@ -475,7 +475,7 @@ def extract_playlist_videos(initial_data : Hash(String, JSON::Any))
     if i = item["playlistVideoRenderer"]?
       video_id = i.dig?("navigationEndpoint", "watchEndpoint", "videoId").try &.as_s || i.dig("videoId").as_s
       plid = i.dig?("navigationEndpoint", "watchEndpoint", "playlistId").try &.as_s || playlist_id
-      index = i.dig?("navigationEndpoint", "watchEndpoint", "index").try &.as_i64 || i.dig("index", "simpleText").as_i64
+      index = i.dig?("navigationEndpoint", "watchEndpoint", "index").try &.as_i64 || i.dig("index", "simpleText").as_s.to_i64
 
       title = i["title"].try { |t| t["simpleText"]? || t["runs"]?.try &.[0]["text"]? }.try &.as_s || ""
       author = i["shortBylineText"]?.try &.["runs"][0]["text"].as_s || ""

--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -377,7 +377,7 @@ def fetch_playlist(plid : String)
       video_count = text.gsub(/\D/, "").to_i? || 0
     elsif text.includes? "view"
       views = text.gsub(/\D/, "").to_i64? || 0_i64
-    else
+    elsif !text.includes? "Pay to watch"
       updated = decode_date(text.lchop("Last updated on ").lchop("Updated "))
     end
   end
@@ -438,7 +438,7 @@ def get_playlist_videos(playlist : InvidiousPlaylist | Playlist, offset : Int32,
       # 100 videos per request
       ctoken = produce_playlist_continuation(playlist.id, offset)
       initial_data = YoutubeAPI.browse(ctoken)
-      videos += extract_playlist_videos(initial_data)
+      videos += extract_playlist_videos(playlist.id, initial_data)
 
       offset += 100
     end
@@ -473,9 +473,9 @@ def extract_playlist_videos(initial_data : Hash(String, JSON::Any))
 
   contents.try &.each do |item|
     if i = item["playlistVideoRenderer"]?
-      video_id = i["navigationEndpoint"]["watchEndpoint"]["videoId"].as_s
-      plid = i["navigationEndpoint"]["watchEndpoint"]["playlistId"].as_s
-      index = i["navigationEndpoint"]["watchEndpoint"]["index"].as_i64
+      video_id = i.dig?("navigationEndpoint", "watchEndpoint", "videoId").try &.as_s || i.dig("videoId").as_s
+      plid = i.dig?("navigationEndpoint", "watchEndpoint", "playlistId").try &.as_s || playlist_id
+      index = i.dig?("navigationEndpoint", "watchEndpoint", "index").try &.as_i64 || i.dig("index", "simpleText").as_s.to_i64
 
       title = i["title"].try { |t| t["simpleText"]? || t["runs"]?.try &.[0]["text"]? }.try &.as_s || ""
       author = i["shortBylineText"]?.try &.["runs"][0]["text"].as_s || ""

--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -438,7 +438,7 @@ def get_playlist_videos(playlist : InvidiousPlaylist | Playlist, offset : Int32,
       # 100 videos per request
       ctoken = produce_playlist_continuation(playlist.id, offset)
       initial_data = YoutubeAPI.browse(ctoken)
-      videos += extract_playlist_videos(playlist.id, initial_data)
+      videos += extract_playlist_videos(initial_data)
 
       offset += 100
     end
@@ -475,7 +475,7 @@ def extract_playlist_videos(initial_data : Hash(String, JSON::Any))
     if i = item["playlistVideoRenderer"]?
       video_id = i.dig?("navigationEndpoint", "watchEndpoint", "videoId").try &.as_s || i.dig("videoId").as_s
       plid = i.dig?("navigationEndpoint", "watchEndpoint", "playlistId").try &.as_s || playlist_id
-      index = i.dig?("navigationEndpoint", "watchEndpoint", "index").try &.as_i64 || i.dig("index", "simpleText").as_s.to_i64
+      index = i.dig?("navigationEndpoint", "watchEndpoint", "index").try &.as_i64 || i.dig("index", "simpleText").as_i64
 
       title = i["title"].try { |t| t["simpleText"]? || t["runs"]?.try &.[0]["text"]? }.try &.as_s || ""
       author = i["shortBylineText"]?.try &.["runs"][0]["text"].as_s || ""


### PR DESCRIPTION
# without this PR
1. go to `/playlist?list=PLmdFyQYShrjfOiKmTtgQFsdorN-0Aq2uJ`
2. notice that playlist page doesn't load
![image](https://github.com/user-attachments/assets/a705edd5-51a1-4590-8e7b-6550f9d23ba3)

# with this PR
1. go to `/playlist?list=PLmdFyQYShrjfOiKmTtgQFsdorN-0Aq2uJ`
2. notice that playlist page now loads
![image](https://github.com/user-attachments/assets/1085b4d6-d71e-445a-8601-06c2bb106df9)

