### PR TITLE
Videos: Add fallback to TvSimply client

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -111,7 +111,7 @@ def extract_video_info(video_id : String)
   if !CONFIG.invidious_companion.present?
     if player_response.dig?("streamingData", "adaptiveFormats", 0, "url").nil?
       LOGGER.warn("Missing URLs for adaptive formats, falling back to other YT clients.")
-      players_fallback = {YoutubeAPI::ClientType::TvHtml5, YoutubeAPI::ClientType::TvSimply, YoutubeAPI::ClientType::WebMobile}
+      players_fallback = {YoutubeAPI::ClientType::TvSimply, YoutubeAPI::ClientType::WebMobile}
 
       players_fallback.each do |player_fallback|
         client_config.client_type = player_fallback


### PR DESCRIPTION
Depends on: https://github.com/iv-org/invidious/pull/5344

Uses the same order Invidious companion uses: https://github.com/iv-org/invidious-companion/blob/d0c4bb79ae4688d019fb281257859e334adb7d8b/src/lib/helpers/youtubePlayerReq.ts#L75