### PR TITLE
Channels: Fix fetching channel playlists

### DIFF
--- a/src/invidious/channels/playlists.cr
+++ b/src/invidious/channels/playlists.cr
@@ -6,19 +6,19 @@ def fetch_channel_playlists(ucid, author, continuation, sort_by)
       case sort_by
       when "last", "last_added"
         # Equivalent to "&sort=lad"
-        # {"2:string": "playlists", "3:varint": 4, "4:varint": 1, "6:varint": 1}
-        "EglwbGF5bGlzdHMYBCABMAE%3D"
+        # {"2:string": "playlists", "3:varint": 4, "4:varint": 1, "6:varint": 1, "110:embedded": {"1:embedded": {"8:string": ""}}}
+        "EglwbGF5bGlzdHMYBCABMAHyBgQKAkIA"
       when "oldest", "oldest_created"
         # formerly "&sort=da"
         # Not available anymore :c or maybe ??
-        # {"2:string": "playlists", "3:varint": 2, "4:varint": 1, "6:varint": 1}
-        "EglwbGF5bGlzdHMYAiABMAE%3D"
+        # {"2:string": "playlists", "3:varint": 2, "4:varint": 1, "6:varint": 1, "110:embedded": {"1:embedded": {"8:string": ""}}}
+        "EglwbGF5bGlzdHMYAiABMAHyBgQKAkIA"
         # {"2:string": "playlists", "3:varint": 1, "4:varint": 1, "6:varint": 1}
         # "EglwbGF5bGlzdHMYASABMAE%3D"
       when "newest", "newest_created"
         # Formerly "&sort=dd"
-        # {"2:string": "playlists", "3:varint": 3, "4:varint": 1, "6:varint": 1}
-        "EglwbGF5bGlzdHMYAyABMAE%3D"
+        # {"2:string": "playlists", "3:varint": 3, "4:varint": 1, "6:varint": 1, "110:embedded": {"1:embedded": {"8:string": ""}}}
+        "EglwbGF5bGlzdHMYAyABMAHyBgQKAkIA"
       end
 
     initial_data = YoutubeAPI.browse(ucid, params: params || "")


### PR DESCRIPTION
Going to a channel's playlists page would show `Error: non 200 status code. Youtube API returned status code 500.`, this broke a few weeks ago. Example URL: https://inv.nadeko.net/channel/UCBR8-60-B28hp2BmDPdntcQ/playlists

I looked at the params used when fetching channel playlists, and on YouTube they appear slightly different from what is used in Invidious. They now include `"110:embedded": {"1:embedded": {"8:string": ""}}` at the end.

After updating the params, the problem appears to be fixed.

I cannot see any difference between playlist ordering when choosing oldest vs newest, but maybe this was already the case before? As a comment says "Not available anymore :c or maybe ??", and YouTube doesn't include the `oldest` sort option. I updated the params regardless, as it's probably better than an error page.

Should fix #5399 

Channel posts also appear to be broken, but I decided not to fix that in this PR as it's a bit more complicated/involved.