### PR TITLE
Dockerfile: Switch to 84codes crystal compiler container image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 ARG OPENSSL_VERSION='3.6.2'
 ARG OPENSSL_SHA256='aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f'
 
-FROM crystallang/crystal:1.20.2-alpine AS dependabot-crystal
+FROM 84codes/crystal:1.20.2-alpine AS dependabot-crystal
 
 # We compile openssl ourselves due to a memory leak in how crystal interacts
 # with openssl


### PR DESCRIPTION
Closes https://github.com/iv-org/invidious/issues/5456

The 84codes Crystal container image builds libgc (bdwgc) with `--enable-large-config`: https://github.com/84codes/crystal-packages/blob/b321bb4358b0140a63573d9d05ccf2f06c5ae040/alpine/Dockerfile#L13-L22

I tested it locally and I'm now going to test it on my fork of Invidious https://git.nadeko.net/Fijxu/invidious/commit/b38791e7ca6b7549e3a894f26f43cb77660c798e