### PR TITLE
Add Livestreams to trending page

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -408,6 +408,7 @@
     "Default": "Default",
     "Music": "Music",
     "Gaming": "Gaming",
+    "Livestreams": "Livestreams",
     "News": "News",
     "Movies": "Movies",
     "Download": "Download",

--- a/src/invidious/trending.cr
+++ b/src/invidious/trending.cr
@@ -4,6 +4,8 @@ def fetch_trending(trending_type, region, locale)
 
   plid = nil
 
+  browse_id = "FEtrending"
+
   case trending_type.try &.downcase
   when "music"
     params = "4gINGgt5dG1hX2NoYXJ0cw%3D%3D"
@@ -11,12 +13,15 @@ def fetch_trending(trending_type, region, locale)
     params = "4gIcGhpnYW1pbmdfY29ycHVzX21vc3RfcG9wdWxhcg%3D%3D"
   when "movies"
     params = "4gIKGgh0cmFpbGVycw%3D%3D"
+  when "livestreams"
+    browse_id = "UC4R8DWoMoI7CAwX8_LjQHig"
+    params = "EgdsaXZldGFikgEDCKEK"
   else # Default
     params = ""
   end
 
   client_config = YoutubeAPI::ClientConfig.new(region: region)
-  initial_data = YoutubeAPI.browse("FEtrending", params: params, client_config: client_config)
+  initial_data = YoutubeAPI.browse(browse_id, params: params, client_config: client_config)
 
   items, _ = extract_items(initial_data)
 

--- a/src/invidious/views/feeds/trending.ecr
+++ b/src/invidious/views/feeds/trending.ecr
@@ -21,7 +21,7 @@
     </div>
     <div class="pure-u-1-3">
         <div class="pure-g" style="text-align:right">
-            <% {"Default", "Music", "Gaming", "Movies"}.each do |option| %>
+            <% {"Default", "Music", "Gaming", "Movies", "Livestreams"}.each do |option| %>
                 <div class="pure-u-1 pure-md-1-3">
                     <% if trending_type == option %>
                         <b><%= translate(locale, option) %></b>


### PR DESCRIPTION
Taken from https://github.com/TeamNewPipe/NewPipeExtractor/blob/b469dcacf07978feb77ef68ff4d1753faf0476b4/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/kiosk/YoutubeLiveExtractor.java

Livestream trending page for US region:

<img height="300" alt="image" src="https://github.com/user-attachments/assets/d37f709e-13d7-49b0-b2d4-e7b03b5516b5" />

Switching to another region shows the Livestream trending page for that region.