### PR TITLE
Prevent timestamp from being set for Livestreams on "Watch on Youtube" links

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -137,16 +137,18 @@ player.on('timeupdate', function () {
 
     // YouTube links
 
-    let elem_yt_watch = document.getElementById('link-yt-watch');
-    if (elem_yt_watch) {
-        let base_url_yt_watch = elem_yt_watch.getAttribute('data-base-url');
-        elem_yt_watch.href = addCurrentTimeToURL(base_url_yt_watch);
-    }
-    
-    let elem_yt_embed = document.getElementById('link-yt-embed');
-    if (elem_yt_embed) {
-        let base_url_yt_embed = elem_yt_embed.getAttribute('data-base-url');
-        elem_yt_embed.href = addCurrentTimeToURL(base_url_yt_embed);
+    if (!video_data.live_now) {
+        let elem_yt_watch = document.getElementById('link-yt-watch');
+        if (elem_yt_watch) {
+            let base_url_yt_watch = elem_yt_watch.getAttribute('data-base-url');
+            elem_yt_watch.href = addCurrentTimeToURL(base_url_yt_watch);
+        }
+        
+        let elem_yt_embed = document.getElementById('link-yt-embed');
+        if (elem_yt_embed) {
+            let base_url_yt_embed = elem_yt_embed.getAttribute('data-base-url');
+            elem_yt_embed.href = addCurrentTimeToURL(base_url_yt_embed);
+        }
     }
 
     // Invidious links

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -65,7 +65,8 @@ we're going to need to do it here in order to allow for translations.
     "vr" => video.vr?,
     "projection_type" => video.projection_type,
     "local_disabled" => CONFIG.disabled?("local"),
-    "support_reddit" => true
+    "support_reddit" => true,
+    "live_now" => video.live_now
 }.to_pretty_json
 %>
 </script>


### PR DESCRIPTION
The timestamp on VideoJS when watching Livestreams is set to 0 at start and it increases while playing the livestream, so when clicking into `Watch on Youtube` and `(Embed)`, the user will be redirected to the Youtube.com livestream but at a specific non live timestamp of the livestream. This PR prevents this from happening