### PR TITLE
Fix community posts when there is a unavailable video in a post

### DIFF
--- a/src/invidious/channels/community.cr
+++ b/src/invidious/channels/community.cr
@@ -143,7 +143,7 @@ def extract_channel_community(items, *, ucid, locale, format, thin_mode, is_sing
                   case attachment.as_h
                   when .has_key?("videoRenderer")
                     parse_item(attachment)
-                      .as(SearchVideo)
+                      .as(SearchVideo | ProblematicTimelineItem)
                       .to_json(locale, json)
                   when .has_key?("backstageImageRenderer")
                     json.object do


### PR DESCRIPTION
Posts with a video that is unavailable returned
`ProblematicTimelineItem` type which was not taken in account for community posts.

Now community posts with a unavailable video will not display an embedded video.

Fixes: https://github.com/iv-org/invidious/issues/5547