### PR TITLE
Fix trending page by leaving livestream and gaming trending pages

### DIFF
--- a/src/invidious/trending.cr
+++ b/src/invidious/trending.cr
@@ -4,20 +4,21 @@ def fetch_trending(trending_type, region, locale)
 
   plid = nil
 
-  browse_id = "FEtrending"
+  browse_id = ""
 
   case trending_type.try &.downcase
-  when "music"
-    params = "4gINGgt5dG1hX2NoYXJ0cw%3D%3D"
   when "gaming"
-    params = "4gIcGhpnYW1pbmdfY29ycHVzX21vc3RfcG9wdWxhcg%3D%3D"
-  when "movies"
-    params = "4gIKGgh0cmFpbGVycw%3D%3D"
+    browse_id = "UCOpNcN46UbXVtpKMrmU4Abg"
+    params = "Egh0cmVuZGluZw%3D%3D"
   when "livestreams"
     browse_id = "UC4R8DWoMoI7CAwX8_LjQHig"
     params = "EgdsaXZldGFikgEDCKEK"
-  else # Default
-    params = ""
+  else
+    # Livestreams is the default one as Youtube removed
+    # the aggregated trending page
+    # https://github.com/iv-org/invidious/issues/5397#issuecomment-3218928458
+    browse_id = "UC4R8DWoMoI7CAwX8_LjQHig"
+    params = "EgdsaXZldGFikgEDCKEK"
   end
 
   client_config = YoutubeAPI::ClientConfig.new(region: region)

--- a/src/invidious/views/feeds/trending.ecr
+++ b/src/invidious/views/feeds/trending.ecr
@@ -21,7 +21,7 @@
     </div>
     <div class="pure-u-1-3">
         <div class="pure-g" style="text-align:right">
-            <% {"Default", "Music", "Gaming", "Movies", "Livestreams"}.each do |option| %>
+            <% {"Livestreams", "Gaming"}.each do |option| %>
                 <div class="pure-u-1 pure-md-1-3">
                     <% if trending_type == option %>
                         <b><%= translate(locale, option) %></b>

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -442,6 +442,7 @@ private module Parsers
         if content_container = special_category_container["horizontalListRenderer"]?
         elsif content_container = special_category_container["expandedShelfContentsRenderer"]?
         elsif content_container = special_category_container["verticalListRenderer"]?
+        elsif content_container = special_category_container["gridRenderer"]?
         else
           # Anything else, such as `horizontalMovieListRenderer` is currently unsupported.
           return


### PR DESCRIPTION
Closes https://github.com/iv-org/invidious/issues/5397

The livestream trending page is now the default. Other trending pages do not work since youtube removed them (refer to https://github.com/iv-org/invidious/issues/5397#issuecomment-3218928458)

Adds `content_container = special_category_container["gridRenderer"]?` in the `CategoryRendererParser` needed for the gaming trending page. The JSON structure of the gaming trending page looked like this:

```json
"contents": {
 "twoColumnBrowseResultsRenderer": {
  "tabs": [
   {
    "tabRenderer": {
     "selected": true,
     "content": {
      "sectionListRenderer": {
       "contents": [
        {
         "itemSectionRenderer": {
          "contents": [
           {
            "shelfRenderer": {
             "title": {
              "runs": [
               {
                "text": "Trending videos"
               }
              ]
             },
             "content": {
              "gridRenderer": { // <- This was added to the CategoryRendererParser
               "items": [
                {
                 "gridVideoRenderer": {
                  "videoId": "sTWztaLjD20",
                  // More video data
                  // ...
                 }
                }
               ]
              }
             }
            }
           }
          ]
         }
        }
       ]
      }
     }
    }
   }
  ]
 }
}
```

Thanks to
https://github.com/TeamNewPipe/NewPipeExtractor/blob/ae2755bf715538dbaed028ecb1a0553c1646710d/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/kiosk/YoutubeTrendingGamingVideosExtractor.java#L11-L13 for the `browse_id` and `params` needed for the gaming trending page.

---

How it looks:

Livestream:

<img height="400" alt="image" src="https://github.com/user-attachments/assets/c865166b-8e88-4f54-a3f9-bf4e20759ba8" />

Gaming:

<img height="400" alt="image" src="https://github.com/user-attachments/assets/847eb3a1-e512-48fc-8fbc-01f74aa7f9d1" />

