### PR TITLE
feat: Add preferences cookie URL to import and export preferences

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -555,6 +555,10 @@ span > select {
   border: 1px solid black;
 }
 
+.light-theme .cookie-url-box {
+  border: 2px solid #444
+}
+
 @media (prefers-color-scheme: light) {
   .no-theme a:hover,
   .no-theme a:active,
@@ -604,6 +608,10 @@ span > select {
 
   .no-theme .error-card {
     border: 1px solid black;
+  }
+
+  .no-theme .cookie-url-box {
+    border: 2px solid #444
   }
 }
 
@@ -671,6 +679,10 @@ body.dark-theme {
   border: 1px solid #5e5e5e;
 }
 
+.dark-theme .cookie-url-box {
+  border: 2px solid #ccc
+}
+
 @media (prefers-color-scheme: dark) {
   .no-theme a:hover,
   .no-theme a:active,
@@ -735,6 +747,10 @@ body.dark-theme {
 
   .no-theme .error-card {
     border: 1px solid #5e5e5e;
+  }
+  
+  .no-theme .cookie-url-box {
+    border: 2px solid #ccc
   }
 }
 
@@ -886,4 +902,8 @@ h1, h2, h3, h4, h5, p,
 .error-issue-template {
   padding: 20px;
   background: rgba(0, 0, 0, 0.12345);
+}
+
+.cookie-url-box {
+  padding: 4px
 }

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -149,6 +149,8 @@
     "preferences_default_home_label": "Default homepage: ",
     "preferences_feed_menu_label": "Feed menu: ",
     "preferences_show_nick_label": "Show nickname on top: ",
+    "preferences_category_cookies": "Preferences cookies",
+    "preferences_cookie_desccription": "With this URL you can restore your preferences on any other browser.",
     "Popular enabled: ": "Popular enabled: ",
     "Top enabled: ": "Top enabled: ",
     "CAPTCHA enabled: ": "CAPTCHA enabled: ",

--- a/src/invidious/views/user/preferences.ecr
+++ b/src/invidious/views/user/preferences.ecr
@@ -371,6 +371,16 @@
             <div class="pure-controls">
                 <button type="submit" class="pure-button pure-button-primary"><%= translate(locale, "Save preferences") %></button>
             </div>
-        </fieldset>
+
+            </fieldset>
+
+            <legend><%= translate(locale, "preferences_category_cookies") %></legend>
+            <%
+                url = "#{HOST_URL}/preferences?preferences=#{encoded_preferences}"
+            %>
+            <p><%= translate(locale, "preferences_cookie_desccription") %></p>
+            <div class="cookie-url-box">
+                <a href="<%= url %>"><%= url %></a>
+            </div>
     </form>
 </div>


### PR DESCRIPTION
Adds a `preferences` query parameter to the `preferences` page to import preferences and it also displays and URL to export the preferences to copy and paste it anywhere:

<img width="1361" height="354" alt="image" src="https://github.com/user-attachments/assets/6b03cb65-c9ae-44c2-9537-624ddd4e8ea2" />

Any suggestions are appreciated because looks kinda off to me.