### PR TITLE
Generate companion check id one time and add missing companion check id on captions

### DIFF
--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -71,15 +71,17 @@
         <% preferred_captions.each do |caption|
             api_captions_url = "/api/v1/captions/"
             api_captions_url = invidious_companion.public_url.to_s + api_captions_url if (invidious_companion)
+            api_captions_check_id = "&check=#{invidious_companion_check_id}"
         %>
-            <track kind="captions" src="<%= api_captions_url %><%= video.id %>?label=<%= caption.name %>" label="<%= caption.name %>">
+            <track kind="captions" src="<%= api_captions_url %><%= video.id %>?label=<%= caption.name %><%= api_captions_check_id %>" label="<%= caption.name %>">
         <% end %>
 
         <% captions.each do |caption|
             api_captions_url = "/api/v1/captions/"
             api_captions_url = invidious_companion.public_url.to_s + api_captions_url if (invidious_companion)
+            api_captions_check_id = "&check=#{invidious_companion_check_id}"
         %>
-            <track kind="captions" src="<%= api_captions_url %><%= video.id %>?label=<%= caption.name %>" label="<%= caption.name %>">
+            <track kind="captions" src="<%= api_captions_url %><%= video.id %>?label=<%= caption.name %><%= api_captions_check_id %>" label="<%= caption.name %>">
         <% end %>
     <% end %>
 </video>


### PR DESCRIPTION
Invidious instances with `server.verify_requests` set to `true` (https://github.com/iv-org/invidious-companion/blob/520eaceedf1ee2371d912daf7c4730ac8eadd8d4/config/config.example.toml#L22) were unable to load captions due to a missing check id.

It also has a commit that generates the check id one time to save some CPU on encryption ;)