### PR TITLE
Downgrade Crystal to 1.16.3 in OCI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 ARG OPENSSL_VERSION='3.5.2'
 ARG OPENSSL_SHA256='c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec'
 
-FROM crystallang/crystal:1.18.2-alpine AS dependabot-crystal
+FROM crystallang/crystal:1.16.3-alpine AS dependabot-crystal
 
 # We compile openssl ourselves due to a memory leak in how crystal interacts
 # with openssl

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -21,7 +21,7 @@ RUN tar -xzvf openssl-${OPENSSL_VERSION}.tar.gz
 RUN cd openssl-${OPENSSL_VERSION} && ./Configure --openssldir=/etc/ssl && make -j$(nproc)
 
 FROM dependabot-alpine AS builder
-RUN apk add --no-cache 'crystal=1.18.2-r0' shards \
+RUN apk add --no-cache 'crystal=1.16.3-r0' shards \
         sqlite-static yaml-static yaml-dev \
         pcre2-static gc-static \
         libxml2-static zlib-static \

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -2,7 +2,7 @@
 ARG OPENSSL_VERSION='3.5.2'
 ARG OPENSSL_SHA256='c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec'
 
-FROM alpine:3.23 AS dependabot-alpine
+FROM alpine:3.22 AS dependabot-alpine
 
 # We compile openssl ourselves due to a memory leak in how crystal interacts
 # with openssl
@@ -63,7 +63,7 @@ RUN --mount=type=cache,target=/root/.cache/crystal if [[ "${release}" == 1 ]] ; 
         --link-flags "-lxml2 -llzma"; \
     fi
 
-FROM alpine:3.23
+FROM alpine:3.22
 RUN apk add --no-cache rsvg-convert ttf-opensans tini tzdata
 WORKDIR /invidious
 RUN addgroup -g 1000 -S invidious && \


### PR DESCRIPTION
After upgrading my instance to 1.18.2 it started to leak memory for some reason, I had to downgrade to 1.16.3 to make it stop. Currently I have no clue what is making Invidious use huge amounts of memory but I suppose is a problem with recent commits. 1.16.3 works fine

<img width="2053" height="853" alt="image" src="https://github.com/user-attachments/assets/9b4097e8-2bbc-432f-b607-1c104ab3d63a" />
