### PR TITLE
Fix Youtube and Invidious links not rewinding their time when video playback position is rewound

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -132,7 +132,7 @@ var timeupdate_last_ts = 5;
 player.on('timeupdate', function () {
     // Only update once every second
     let current_ts = Math.floor(player.currentTime());
-    if (current_ts > timeupdate_last_ts) timeupdate_last_ts = current_ts;
+    if (current_ts != timeupdate_last_ts) timeupdate_last_ts = current_ts;
     else return;
 
     // YouTube links
@@ -143,7 +143,7 @@ player.on('timeupdate', function () {
             let base_url_yt_watch = elem_yt_watch.getAttribute('data-base-url');
             elem_yt_watch.href = addCurrentTimeToURL(base_url_yt_watch);
         }
-        
+
         let elem_yt_embed = document.getElementById('link-yt-embed');
         if (elem_yt_embed) {
             let base_url_yt_embed = elem_yt_embed.getAttribute('data-base-url');
@@ -160,7 +160,7 @@ player.on('timeupdate', function () {
         let base_url_iv_embed = elem_iv_embed.getAttribute('data-base-url');
         elem_iv_embed.href = addCurrentTimeToURL(base_url_iv_embed, domain);
     }
-    
+
     let elem_iv_other = document.getElementById('link-iv-other');
     if (elem_iv_other) {
         let base_url_iv_other = elem_iv_other.getAttribute('data-base-url');
@@ -628,7 +628,7 @@ function toggle_caption_window() {
     player.textTrackSettings.setValues({ windowOpacity: options.windowOpacity[newIndex] });
     update_captions();
 }
-  
+
 function toggle_caption_opacity() {
     const numOptions = options.textOpacity.length;
     const textOpacity = player.textTrackSettings.getValues().textOpacity || '1';
@@ -733,7 +733,7 @@ addEventListener('keydown', function (e) {
 
         case '>': action = increase_playback_rate.bind(this, 1); break;
         case '<': action = increase_playback_rate.bind(this, -1); break;
-        
+
         case '=': action = increase_caption_size.bind(this, 1); break;
         case '-': action = increase_caption_size.bind(this, -1); break;
 


### PR DESCRIPTION
When rewinding a video, the time in the links **Watch on Youtube**, **(Embed)**, **Switch Invidious Instance**, **Embed Link** was not rewound, so the time in the links only increased and it didn't decrease depending of the video playback timestamp position.

If it's not clear, here is a video of the fix, trying to rewind without this fix, makes the `t` parameter only increase.

https://github.com/user-attachments/assets/f86cc2ba-a574-4ce8-bdbf-02b9adc1bd34

This fix does not affect at all with the saved playback position of each video (**Save playback position:** preference in Invidious settings that saves the video playback positions in Local Storage), the `timeupdate_last_ts` was only used here.