### PR TITLE
Update shard.yml to include target that was removed in commit 9d54cf9

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,6 +5,10 @@ authors:
   - Invidious team <contact@invidious.io>
   - Contributors!
 
+targets:
+  invidious:
+    main: src/invidious.cr
+
 description: |
    Invidious is an alternative front-end to YouTube 
 


### PR DESCRIPTION
[shard.yml]
- Include a target for LSPs to use as an entrypoint: (https://github.com/elbywan/crystalline?tab=readme-ov-file#entry-point)

This helps Crystalline to determine requires and project structure