### PR TITLE
fix: add missing embedded protobuf message in continuation token for channel videos

### DIFF
--- a/src/invidious/channels/videos.cr
+++ b/src/invidious/channels/videos.cr
@@ -134,7 +134,7 @@ module Invidious::Channel::Tabs
         "2:embedded" => {
           "1:string" => "00000000-0000-0000-0000-000000000000",
         },
-        "4:varint" => sort_options_videos_short(sort_by),
+        "4:varint"   => sort_options_videos_short(sort_by),
         "7:embedded" => {
           "1:string" => "00000000-0000-0000-0000-000000000000",
           "3:varint" => sort_options_videos_short(sort_by),
@@ -162,7 +162,11 @@ module Invidious::Channel::Tabs
         "2:embedded" => {
           "1:string" => "00000000-0000-0000-0000-000000000000",
         },
-        "5:varint" => sort_by_numerical,
+        "5:varint"   => sort_by_numerical,
+        "8:embedded" => {
+          "1:string" => "00000000-0000-0000-0000-000000000000",
+          "3:varint" => sort_by_numerical,
+        },
       },
     }
 


### PR DESCRIPTION
Now the protobuf of continuation tokens for channel videos contains:

```
      8 {
        1: "<some_uuid>"
        3: 2
      }
```

`3:varint` seems to be the same value as `4:varint`

Fixes https://github.com/iv-org/invidious/issues/5613 and fixes 400 errors when trying to access a channel in Invidious.

---

Protobuf decoding:

```
echo "4qmFsgKdARIYVUM5TUFoWlFRZDllZ3dXQ3hyd1NJc0pRGoABOGdaWUdsWjZWQkltQ2lRMllqTmxObU01TUMwd01EQXdMVEk1TVdNdFltUm1OaTFrTkdZMU5EZGxZbVV3WmpRZ0FrSW9DaVEyWWpObE5tTTVNQzB3TURBd0xUSTVNV010WW1SbU5pMWtOR1kxTkRkbFltVXdaalFZQWclM0QlM0Q=" | base64 -d | protoc --decode_raw

80226972 {
  2: "UC9MAhZQQd9egwWCxrwSIsJQ"
  3: "8gZYGlZ6VBImCiQ2YjNlNmM5MC0wMDAwLTI5MWMtYmRmNi1kNGY1NDdlYmUwZjQgAkIoCiQ2YjNlNmM5MC0wMDAwLTI5MWMtYmRmNi1kNGY1NDdlYmUwZjQYAg%3D%3D"
}
```

```
echo "8gZYGlZ6VBImCiQ2YjNlNmM5MC0wMDAwLTI5MWMtYmRmNi1kNGY1NDdlYmUwZjQgAkIoCiQ2YjNlNmM5MC0wMDAwLTI5MWMtYmRmNi1kNGY1NDdlYmUwZjQYAg==" | base64 -d | protoc --decode_raw

110 {
  3 {
    15 {
      2 {
        1: "6b3e6c90-0000-291c-bdf6-d4f547ebe0f4"
      }
      4: 2
      8 {
        1: "6b3e6c90-0000-291c-bdf6-d4f547ebe0f4"
        3: 2
      }
    }
  }
}
```