### PR TITLE
playlist: parse playlist thumbnails for topic autogenerated playlists

### DIFF
--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -359,6 +359,9 @@ def fetch_playlist(plid : String)
   thumbnail = playlist_info.dig?(
     "thumbnailRenderer", "playlistVideoThumbnailRenderer",
     "thumbnail", "thumbnails", 0, "url"
+  ).try &.as_s || playlist_info.dig?(
+    "thumbnailRenderer", "playlistCustomThumbnailRenderer",
+    "thumbnail", "thumbnails", 0, "url"
   ).try &.as_s
 
   views = 0_i64


### PR DESCRIPTION
#5515 

To test:
Go to `{YOUR INSTANCE}/api/v1/playlists/OLAK5uy_nh7Py_NVbO3OLxpNJ8bxmb-fqsLuyhOYA`
See playlistThumbnail is now populated
Before:
<img width="688" height="166" alt="image" src="https://github.com/user-attachments/assets/c2c53d44-a12f-4647-8857-18616f63a999" />

After:
<img width="1293" height="162" alt="image" src="https://github.com/user-attachments/assets/902eb691-870b-43ba-9d66-fb57dc247f24" />
