### PR TITLE
Channels: parse pronouns and display them on channel page

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -75,6 +75,16 @@ body {
   height: auto;
 }
 
+.channel-profile > .channel-name-pronouns {
+    display: inline-block;
+}
+
+.channel-profile > .channel-name-pronouns > .channel-pronouns {
+  font-style: italic;
+  font-size: .8em;
+  font-weight: lighter;
+}
+
 body a.channel-owner {
   background-color: #008bec;
   color: #fff;
@@ -406,7 +416,12 @@ input[type="search"]::-webkit-search-cancel-button {
 
 p.channel-name { margin: 0; overflow-wrap: anywhere;}
 p.video-data   { margin: 0; font-weight: bold; font-size: 80%; }
-.channel-profile > .channel-name { overflow-wrap: anywhere;}
+
+.channel-profile > .channel-name,
+.channel-profile > .channel-name-pronouns >  .channel-name 
+{
+  overflow-wrap: anywhere;
+}
 
 
 /*

--- a/src/invidious/routes/api/v1/channels.cr
+++ b/src/invidious/routes/api/v1/channels.cr
@@ -104,6 +104,7 @@ module Invidious::Routes::API::V1::Channels
         json.field "tabs", channel.tabs
         json.field "tags", channel.tags
         json.field "authorVerified", channel.verified
+        json.field "pronouns", channel.pronouns
 
         json.field "latestVideos" do
           json.array do

--- a/src/invidious/views/components/channel_info.ecr
+++ b/src/invidious/views/components/channel_info.ecr
@@ -12,7 +12,10 @@
     <div class="pure-u-1-2 flex-left flexible">
         <div class="channel-profile">
             <img src="/ggpht<%= channel_profile_pic %>" alt="" />
-            <span class="channel-name"><%= author %></span><% if !channel.verified.nil? && channel.verified %>&nbsp;<i class="icon ion ion-md-checkmark-circle"></i><% end %>
+            <div class="channel-name-pronouns">
+                <span class="channel-name"><%= author %></span><% if !channel.verified.nil? && channel.verified %>&nbsp;<i class="icon ion ion-md-checkmark-circle"></i><% end %>
+                <% if !channel.pronouns.nil? %><br /><span class="channel-pronouns"><%= channel.pronouns %></span><% end %>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
This PR parses and displays channel pronouns.

# Testing:

## Channel with pronouns:
1- Go to `{INVIDIOUS INSTANCE}/api/v1/channels/UCw-aR42z5gUcarpPGN5OKfA`
2 - see pronoun field below channel name
<img width="1613" height="490" alt="image" src="https://github.com/user-attachments/assets/9b09ee50-cf2a-4227-833c-e19282fcc682" />


1 - Go to `{INVIDIOUS INSTANCE}/channel/UCw-aR42z5gUcarpPGN5OKfA`
2- See pronoun field
<img width="1619" height="480" alt="image" src="https://github.com/user-attachments/assets/566c32ab-b707-4661-88d6-86f01c58ec4b" />

## Channel with no prouns

1 - Go to `{INVIDIOUS INSTANCE}/channel/UCX6OQ3DkcsbYNE6H8uQQuVA`
2 - Don't see pronouns
<img width="1619" height="480" alt="image" src="https://github.com/user-attachments/assets/4dcf2587-dd55-487e-9481-34ef1bfa6ed5" />


1 - Go to `{INVIDIOUS INSTANCE}/api/v1/channels/UCX6OQ3DkcsbYNE6H8uQQuVA`
2 - see empty pronouns
<img width="1619" height="480" alt="image" src="https://github.com/user-attachments/assets/e073a104-e1fe-486a-80a1-e332820b7f3d" />


