### PR TITLE
Playlist API: return empty author url if ucid is empty

### DIFF
--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -107,7 +107,11 @@ struct Playlist
 
       json.field "author", self.author
       json.field "authorId", self.ucid
-      json.field "authorUrl", "/channel/#{self.ucid}"
+      if !self.ucid.empty?
+        json.field "authorUrl", "/channel/#{self.ucid}"
+      else
+        json.field "authorUrl", ""
+      end
       json.field "subtitle", self.subtitle
 
       json.field "authorThumbnails" do


### PR DESCRIPTION
Split off from #5616 


To test:
Go to `{YOUR INSTANCE}/api/v1/playlists/OLAK5uy_nh7Py_NVbO3OLxpNJ8bxmb-fqsLuyhOYA`
See that authorUrl is now empty.

Before:
<img width="688" height="166" alt="image" src="https://github.com/user-attachments/assets/c2c53d44-a12f-4647-8857-18616f63a999" />

After:
<img width="1293" height="162" alt="image" src="https://github.com/user-attachments/assets/902eb691-870b-43ba-9d66-fb57dc247f24" />