### PR TITLE
Add `enable_api` config option to disable unauthenticated API endpoints

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -217,6 +217,7 @@ end
 Kemal.config.powered_by_header = false
 add_handler FilteredCompressHandler.new
 add_handler APIHandler.new
+add_handler DisableAPIHandler.new
 add_handler AuthHandler.new
 add_handler DenyFrame.new
 

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -127,6 +127,10 @@ class Config
   property login_enabled : Bool = true
   property registration_enabled : Bool = true
   property statistics_enabled : Bool = false
+  # When set to false, disables the unauthenticated API endpoints
+  # (videos, channels, search, etc.) that can be abused by bots.
+  # Authenticated API endpoints (/api/v1/auth/*) are unaffected.
+  property enable_api : Bool = true
   property admins : Array(String) = [] of String
   property external_port : Int32? = nil
   property default_user_preferences : ConfigPreferences = ConfigPreferences.from_yaml("")

--- a/src/invidious/helpers/handlers.cr
+++ b/src/invidious/helpers/handlers.cr
@@ -133,6 +133,29 @@ class APIHandler < Kemal::Handler
   end
 end
 
+class DisableAPIHandler < Kemal::Handler
+  # Blocks unauthenticated API endpoints when `enable_api` is false.
+  # Authenticated endpoints (/api/v1/auth/*) and stats are excluded.
+  {% for method in %w(GET POST PUT HEAD DELETE PATCH OPTIONS) %}
+  only ["/api/v1/*"], {{method}}
+  {% end %}
+  exclude ["/api/v1/auth/*"], "GET"
+  exclude ["/api/v1/auth/*"], "POST"
+  exclude ["/api/v1/auth/*"], "DELETE"
+  exclude ["/api/v1/auth/*"], "PATCH"
+  exclude ["/api/v1/auth/*"], "PUT"
+  exclude ["/api/v1/stats"], "GET"
+
+  def call(env)
+    if only_match?(env) && !exclude_match?(env) && !CONFIG.enable_api
+      env.response.content_type = "application/json"
+      env.response.status_code = 403
+      return {"error" => "The API has been disabled by the administrator."}.to_json
+    end
+    call_next env
+  end
+end
+
 class DenyFrame < Kemal::Handler
   exclude ["/embed/*"]
 


### PR DESCRIPTION
## Summary

Adds a new `enable_api` configuration option (default: `true`) that allows instance administrators to easily disable unauthenticated API endpoints to prevent abuse by bots and scrapers.

## Changes

- **`src/invidious/config.cr`**: Added `enable_api : Bool = true` property
- **`src/invidious/helpers/handlers.cr`**: Added `DisableAPIHandler` Kemal handler that intercepts `/api/v1/*` requests and returns 403 when the API is disabled
- **`src/invidious.cr`**: Registered the new handler

## Behavior

When `enable_api: false` is set in the config:
- All unauthenticated API endpoints (`/api/v1/*`) return `403` with `{"error": "The API has been disabled by the administrator."}`
- Authenticated endpoints (`/api/v1/auth/*`) remain available
- Stats endpoint (`/api/v1/stats`) remains available
- Default is `true` (no change for existing instances)

## Usage

```yaml
# config.yml
enable_api: false
```

Fixes #5599