### PR TITLE
Add option to disable easy to abuse API endpoints

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -436,6 +436,19 @@ full_refresh: false
 ##
 feed_threads: 1
 
+##
+## Setting to disable easy to abuse API endpoints that can
+## be spammed and therefore blocking your Invidious instance.
+##
+## Notes: The following API endpoints will be disabled:
+##  - /api/v1/videos
+##  - /api/v1/clips
+##  - /api/v1/transcripts
+##
+## Accepted values: true, false
+## Default: false
+##
+disable_api: false
 
 jobs:
 

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -185,7 +185,6 @@ https_only: false
 #  path: /tmp/invidious.sock
 #  permissions: 777
 
-
 # -----------------------------
 #  Network (outbound)
 # -----------------------------
@@ -207,7 +206,6 @@ https_only: false
 ## Default: 100
 ##
 #pool_size: 100
-
 
 ##
 ## Additional cookies to be sent when requesting the youtube API.
@@ -242,7 +240,6 @@ https_only: false
 #  password:
 #  host:
 #  port:
-
 
 ##
 ## Use Innertube's transcripts API instead of timedtext for closed captions
@@ -323,7 +320,6 @@ https_only: false
 ## Default: false
 ##
 #statistics_enabled: false
-
 
 # -----------------------------
 #  Users and accounts
@@ -440,6 +436,8 @@ feed_threads: 1
 ## Setting to disable easy to abuse API endpoints that can
 ## be spammed and therefore blocking your Invidious instance.
 ##
+## Useful for public instance maintainers.
+##
 ## Notes: The following API endpoints will be disabled:
 ##  - /api/v1/videos
 ##  - /api/v1/clips
@@ -448,13 +446,11 @@ feed_threads: 1
 ## Accepted values: true, false
 ## Default: false
 ##
-disable_api: false
+disable_abusable_api: false
 
 jobs:
-
   ## Options for the database cleaning job
   clear_expired_items:
-
     ## Enable/Disable job
     ##
     ## Accepted values: true, false
@@ -464,7 +460,6 @@ jobs:
 
   ## Options for the channels updater job
   refresh_channels:
-
     ## Enable/Disable job
     ##
     ## Accepted values: true, false
@@ -474,14 +469,12 @@ jobs:
 
   ## Options for the RSS feeds updater job
   refresh_feeds:
-
     ## Enable/Disable job
     ##
     ## Accepted values: true, false
     ## Default: true
     ##
     enable: true
-
 
 # -----------------------------
 #  Miscellaneous
@@ -681,7 +674,6 @@ default_user_preferences:
   ##
   #captions: ["", "", ""]
 
-
   # -----------------------------
   #  Interface
   # -----------------------------
@@ -783,7 +775,6 @@ default_user_preferences:
   ##
   #related_videos: true
 
-
   # -----------------------------
   #  Video player behavior
   # -----------------------------
@@ -846,7 +837,6 @@ default_user_preferences:
   ## Default: false
   ##
   #video_loop: false
-
 
   # -----------------------------
   #  Video playback settings
@@ -958,7 +948,6 @@ default_user_preferences:
   ## Default: published
   ##
   #sort: published
-
 
   # -----------------------------
   #  Miscellaneous

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -217,6 +217,7 @@ end
 Kemal.config.powered_by_header = false
 add_handler FilteredCompressHandler.new
 add_handler APIHandler.new
+add_handler DisableAbusableAPIHandler.new
 add_handler AuthHandler.new
 add_handler DenyFrame.new
 

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -180,6 +180,9 @@ class Config
   # Playlist length limit
   property playlist_length_limit : Int32 = 500
 
+  # Disable easy to abuse API endpoints
+  property disable_api : Bool = false
+
   def disabled?(option)
     case disabled = CONFIG.disable_proxy
     when Bool

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -181,7 +181,7 @@ class Config
   property playlist_length_limit : Int32 = 500
 
   # Disable easy to abuse API endpoints
-  property disable_api : Bool = false
+  property disable_abusable_api : Bool = false
 
   def disabled?(option)
     case disabled = CONFIG.disable_proxy

--- a/src/invidious/helpers/handlers.cr
+++ b/src/invidious/helpers/handlers.cr
@@ -133,6 +133,26 @@ class APIHandler < Kemal::Handler
   end
 end
 
+class DisableAbusableAPIHandler < Kemal::Handler
+  {% for method in %w(GET HEAD) %}
+    # This endpoints make a video request to Invidious companion.
+    {% for endpoint in %w(videos clips transcripts) %}
+      only ["/api/v1/{{ endpoint.id }}/:id"], {{ method }}
+    {% end %}
+  {% end %}
+
+  def call(env)
+    return call_next env unless only_match?(env) && CONFIG.disable_api
+
+    env.response.content_type = "application/json"
+    env.response.status_code = 403
+    message = {"error" => "This API endpoint has been disabled by the administrator."}.to_json
+    env.response.print message
+    env.response.close
+    return
+  end
+end
+
 class DenyFrame < Kemal::Handler
   exclude ["/embed/*"]
 

--- a/src/invidious/helpers/handlers.cr
+++ b/src/invidious/helpers/handlers.cr
@@ -142,7 +142,7 @@ class DisableAbusableAPIHandler < Kemal::Handler
   {% end %}
 
   def call(env)
-    return call_next env unless only_match?(env) && CONFIG.disable_api
+    return call_next env unless only_match?(env) && CONFIG.disable_abusable_api
 
     env.response.content_type = "application/json"
     env.response.status_code = 403


### PR DESCRIPTION
Supersedes https://github.com/iv-org/invidious/pull/5628

The API endpoints that will be disabled when this option are:
 - /api/v1/videos
 - /api/v1/clips
 - /api/v1/transcripts

Add a `disable_abusable_api` config option, although it could be changed to a more flexible option to let the instance owner disable the API endpoints they want to disable, but I'm not too sure, what do you think @unixfox?

There is still API endponts that need some sort of validation or connection/proxying to Invidious companion like
`/api/v1/captions` and `/api/v1/storyboards` since they also do a video request to Invidious companion. I'm not sure if the `/next` API endpoint could be used to gather that type of information, if so, that would be better.

Closes #5599