### PR TITLE
Remove trailing whitespaces from codebase

### DIFF
--- a/assets/js/_helpers.js
+++ b/assets/js/_helpers.js
@@ -211,9 +211,9 @@ window.helpers = window.helpers || {
                         helpers.storage.remove(key);
                     }
                 },
-                set: function (key, value) { 
+                set: function (key, value) {
                     let encoded_value = encodeURIComponent(JSON.stringify(value))
-                    localStorage.setItem(key, encoded_value); 
+                    localStorage.setItem(key, encoded_value);
                 },
                 remove: function (key) { localStorage.removeItem(key); }
             };

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -143,7 +143,7 @@ player.on('timeupdate', function () {
             let base_url_yt_watch = elem_yt_watch.getAttribute('data-base-url');
             elem_yt_watch.href = addCurrentTimeToURL(base_url_yt_watch);
         }
-        
+
         let elem_yt_embed = document.getElementById('link-yt-embed');
         if (elem_yt_embed) {
             let base_url_yt_embed = elem_yt_embed.getAttribute('data-base-url');
@@ -160,7 +160,7 @@ player.on('timeupdate', function () {
         let base_url_iv_embed = elem_iv_embed.getAttribute('data-base-url');
         elem_iv_embed.href = addCurrentTimeToURL(base_url_iv_embed, domain);
     }
-    
+
     let elem_iv_other = document.getElementById('link-iv-other');
     if (elem_iv_other) {
         let base_url_iv_other = elem_iv_other.getAttribute('data-base-url');
@@ -628,7 +628,7 @@ function toggle_caption_window() {
     player.textTrackSettings.setValues({ windowOpacity: options.windowOpacity[newIndex] });
     update_captions();
 }
-  
+
 function toggle_caption_opacity() {
     const numOptions = options.textOpacity.length;
     const textOpacity = player.textTrackSettings.getValues().textOpacity || '1';
@@ -733,7 +733,7 @@ addEventListener('keydown', function (e) {
 
         case '>': action = increase_playback_rate.bind(this, 1); break;
         case '<': action = increase_playback_rate.bind(this, -1); break;
-        
+
         case '=': action = increase_caption_size.bind(this, 1); break;
         case '-': action = increase_caption_size.bind(this, -1); break;
 

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -53,7 +53,7 @@ db:
 ##
 ## When this setting is commented out, Invidious companion is not used.
 ## Otherwise, Invidious will proxy the requests to Invidious companion.
-## 
+##
 ## Note: multiple URL can be configured. In this case, Invidious will
 ## randomly pick one every time video data needs to be retrieved. This
 ## URL is then kept in the video metadata cache to allow video playback
@@ -63,7 +63,7 @@ db:
 ## The parameter private_url is required for the internal communication
 ## between Invidious companion and Invidious.
 ##
-## The optional parameter public_url is the public URL from which 
+## The optional parameter public_url is the public URL from which
 ## Invidious companion is listening to the requests from the user(s).
 ## When this setting is commented out, Invidious proxy all requests to
 ## Invidious companion. Useful for simple setups.
@@ -232,7 +232,7 @@ https_only: false
 ## Configuration for using a HTTP proxy
 ## If unset, then no HTTP proxy will be used.
 ## Proxy type supported: HTTP, HTTPS
-## 
+##
 ## This is not used for loading the video streams from YouTube servers (circumvent YouTube restrictions)
 ## Please instead configure the proxy in Invidious companion:
 ## https://github.com/iv-org/invidious-companion/blob/master/config/config.example.toml
@@ -885,7 +885,7 @@ default_user_preferences:
   ## Default: true
   ##
   #vr_mode: true
-  
+
   ##
   ## Save the playback position
   ## Allow to continue watching at the previous position when

--- a/scripts/git/pre-commit
+++ b/scripts/git/pre-commit
@@ -3,7 +3,7 @@
 
 # Crystal linter
 # This is a modified version of the pre-commit hook from the crystal repo. https://github.com/crystal-lang/crystal/blob/master/scripts/git/pre-commit
-# Please refer to that if you'd like an version that doesn't automatically format staged files. 
+# Please refer to that if you'd like an version that doesn't automatically format staged files.
 changed_cr_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.cr$')
 if [ ! -z "$changed_cr_files" ]; then
   if [ -x bin/crystal ]; then

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -25,7 +25,7 @@
                audio_streams.each_with_index do |fmt, i|
                 src_url  = "/latest_version?id=#{video.id}&itag=#{fmt["itag"]}"
                 src_url += "&local=true" if params.local
-                src_url = invidious_companion.public_url.to_s + src_url + 
+                src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
                 bitrate = fmt["bitrate"]

--- a/src/invidious/views/template.ecr
+++ b/src/invidious/views/template.ecr
@@ -159,7 +159,7 @@
                             <% end %>
                             @ <%= CURRENT_BRANCH %>
                             <% if CURRENT_TAG != "" %>
-                            (                                
+                            (
                                 <% if CONFIG.modified_source_code_url %>
                                     <a href="<%= CONFIG.modified_source_code_url %>/releases/tag/<%= CURRENT_TAG %>"><%= CURRENT_TAG %></a>
                                 <% else %>


### PR DESCRIPTION
Removes trailing whitespaces found across the codebase using `find . -type f -exec grep -lE ' +$' {} +`