### PR TITLE
Parse channel handle and display it on channel page and API

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -75,12 +75,11 @@ body {
   height: auto;
 }
 
-.channel-profile > .channel-name-pronouns {
+.channel-profile > .channel-info {
     display: inline-block;
 }
 
-.channel-profile > .channel-name-pronouns > .channel-pronouns {
-  font-style: italic;
+.channel-profile > .channel-info > .channel-metadata > .channel-metadata-item {
   font-size: .8em;
   font-weight: lighter;
 }
@@ -418,7 +417,7 @@ p.channel-name { margin: 0; overflow-wrap: anywhere;}
 p.video-data   { margin: 0; font-weight: bold; font-size: 80%; }
 
 .channel-profile > .channel-name,
-.channel-profile > .channel-name-pronouns >  .channel-name 
+.channel-profile > .channel-info > .channel-metadata > .channel-metadata-item
 {
   overflow-wrap: anywhere;
 }

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -416,7 +416,7 @@ input[type="search"]::-webkit-search-cancel-button {
 p.channel-name { margin: 0; overflow-wrap: anywhere;}
 p.video-data   { margin: 0; font-weight: bold; font-size: 80%; }
 
-.channel-profile > .channel-name,
+.channel-profile > .channel-info > .channel-name,
 .channel-profile > .channel-info > .channel-metadata > .channel-metadata-item
 {
   overflow-wrap: anywhere;

--- a/src/invidious/channels/about.cr
+++ b/src/invidious/channels/about.cr
@@ -174,18 +174,15 @@ def get_about_info(ucid, locale) : AboutChannel
     metadata_rows.each do |row|
       metadata_parts = row.dig?("metadataParts")
 
-      subscribe_metadata_part = metadata_parts.try &.as_a.find { |i| i.dig?("text", "content").try &.as_s.includes?("subscribers") }
-      if !subscribe_metadata_part.nil?
+      if (subscribe_metadata_part = metadata_parts.try &.as_a.find { |i| i.dig?("text", "content").try &.as_s.includes?("subscribers") })
         sub_count = short_text_to_number(subscribe_metadata_part.dig("text", "content").as_s.split(" ")[0]).to_i32
       end
 
-      channel_handle_part = metadata_parts.try &.as_a.find { |i| i.dig?("text", "content").try &.as_s.includes?("@") }
-      if !channel_handle_part.nil?
+      if (channel_handle_part = metadata_parts.try &.as_a.find { |i| i.dig?("text", "content").try &.as_s.includes?("@") })
         channel_handle = channel_handle_part.dig("text", "content").as_s
       end
 
-      pronoun_metadata_part = metadata_parts.try &.as_a.find { |i| i.dig?("tooltip").try &.as_s.includes?("Pronouns") }
-      if !pronoun_metadata_part.nil?
+      if (pronoun_metadata_part = metadata_parts.try &.as_a.find { |i| i.dig?("tooltip").try &.as_s.includes?("Pronouns") })
         pronouns = pronoun_metadata_part.dig("text", "content").as_s
       end
 

--- a/src/invidious/channels/about.cr
+++ b/src/invidious/channels/about.cr
@@ -190,7 +190,7 @@ def get_about_info(ucid, locale) : AboutChannel
       end
 
       # This is to prevent processing more metadata parts if we already have
-      # all the parts we care about, which are the ones bellow
+      # all the parts we care about, which are the ones below
       break if sub_count != 0 && !pronouns.nil? && !author_handle.nil?
     end
   end

--- a/src/invidious/channels/about.cr
+++ b/src/invidious/channels/about.cr
@@ -2,7 +2,7 @@
 record AboutChannel,
   ucid : String,
   author : String,
-  author_handle : String?,
+  channel_handle : String?,
   auto_generated : Bool,
   author_url : String,
   author_thumbnail : String,
@@ -168,7 +168,7 @@ def get_about_info(ucid, locale) : AboutChannel
 
   sub_count = 0
   pronouns = nil
-  author_handle = nil
+  channel_handle = nil
 
   if (metadata_rows = initdata.dig?("header", "pageHeaderRenderer", "content", "pageHeaderViewModel", "metadata", "contentMetadataViewModel", "metadataRows").try &.as_a)
     metadata_rows.each do |row|
@@ -179,9 +179,9 @@ def get_about_info(ucid, locale) : AboutChannel
         sub_count = short_text_to_number(subscribe_metadata_part.dig("text", "content").as_s.split(" ")[0]).to_i32
       end
 
-      author_handle_part = metadata_parts.try &.as_a.find { |i| i.dig?("text", "content").try &.as_s.includes?("@") }
-      if !author_handle_part.nil?
-        author_handle = author_handle_part.dig("text", "content").as_s
+      channel_handle_part = metadata_parts.try &.as_a.find { |i| i.dig?("text", "content").try &.as_s.includes?("@") }
+      if !channel_handle_part.nil?
+        channel_handle = channel_handle_part.dig("text", "content").as_s
       end
 
       pronoun_metadata_part = metadata_parts.try &.as_a.find { |i| i.dig?("tooltip").try &.as_s.includes?("Pronouns") }
@@ -191,14 +191,14 @@ def get_about_info(ucid, locale) : AboutChannel
 
       # This is to prevent processing more metadata parts if we already have
       # all the parts we care about, which are the ones below
-      break if sub_count != 0 && !pronouns.nil? && !author_handle.nil?
+      break if sub_count != 0 && !pronouns.nil? && !channel_handle.nil?
     end
   end
 
   AboutChannel.new(
     ucid: ucid,
     author: author,
-    author_handle: author_handle,
+    channel_handle: channel_handle,
     auto_generated: auto_generated,
     author_url: author_url,
     author_thumbnail: author_thumbnail,

--- a/src/invidious/channels/about.cr
+++ b/src/invidious/channels/about.cr
@@ -2,6 +2,7 @@
 record AboutChannel,
   ucid : String,
   author : String,
+  author_handle : String?,
   auto_generated : Bool,
   author_url : String,
   author_thumbnail : String,
@@ -167,26 +168,37 @@ def get_about_info(ucid, locale) : AboutChannel
 
   sub_count = 0
   pronouns = nil
+  author_handle = nil
 
   if (metadata_rows = initdata.dig?("header", "pageHeaderRenderer", "content", "pageHeaderViewModel", "metadata", "contentMetadataViewModel", "metadataRows").try &.as_a)
     metadata_rows.each do |row|
-      subscribe_metadata_part = row.dig?("metadataParts").try &.as_a.find { |i| i.dig?("text", "content").try &.as_s.includes?("subscribers") }
+      metadata_parts = row.dig?("metadataParts")
+
+      subscribe_metadata_part = metadata_parts.try &.as_a.find { |i| i.dig?("text", "content").try &.as_s.includes?("subscribers") }
       if !subscribe_metadata_part.nil?
         sub_count = short_text_to_number(subscribe_metadata_part.dig("text", "content").as_s.split(" ")[0]).to_i32
       end
 
-      pronoun_metadata_part = row.dig?("metadataParts").try &.as_a.find { |i| i.dig?("tooltip").try &.as_s.includes?("Pronouns") }
+      author_handle_part = metadata_parts.try &.as_a.find { |i| i.dig?("text", "content").try &.as_s.includes?("@") }
+      if !author_handle_part.nil?
+        author_handle = author_handle_part.dig("text", "content").as_s
+      end
+
+      pronoun_metadata_part = metadata_parts.try &.as_a.find { |i| i.dig?("tooltip").try &.as_s.includes?("Pronouns") }
       if !pronoun_metadata_part.nil?
         pronouns = pronoun_metadata_part.dig("text", "content").as_s
       end
 
-      break if sub_count != 0 && !pronouns.nil?
+      # This is to prevent processing more metadata parts if we already have
+      # all the parts we care about, which are the ones bellow
+      break if sub_count != 0 && !pronouns.nil? && !author_handle.nil?
     end
   end
 
   AboutChannel.new(
     ucid: ucid,
     author: author,
+    author_handle: author_handle,
     auto_generated: auto_generated,
     author_url: author_url,
     author_thumbnail: author_thumbnail,

--- a/src/invidious/routes/api/v1/channels.cr
+++ b/src/invidious/routes/api/v1/channels.cr
@@ -48,7 +48,7 @@ module Invidious::Routes::API::V1::Channels
       # TODO: Refactor into `to_json` for InvidiousChannel
       json.object do
         json.field "author", channel.author
-        json.field "authorHandle", channel.author_handle
+        json.field "channelHandle", channel.channel_handle
         json.field "authorId", channel.ucid
         json.field "authorUrl", channel.author_url
 

--- a/src/invidious/routes/api/v1/channels.cr
+++ b/src/invidious/routes/api/v1/channels.cr
@@ -48,6 +48,7 @@ module Invidious::Routes::API::V1::Channels
       # TODO: Refactor into `to_json` for InvidiousChannel
       json.object do
         json.field "author", channel.author
+        json.field "authorHandle", channel.author_handle
         json.field "authorId", channel.ucid
         json.field "authorUrl", channel.author_url
 

--- a/src/invidious/views/components/channel_info.ecr
+++ b/src/invidious/views/components/channel_info.ecr
@@ -16,8 +16,8 @@
                 <span class="channel-name"><%= author %></span><% if !channel.verified.nil? && channel.verified %>&nbsp;<i class="icon ion ion-md-checkmark-circle"></i><% end %>
                 <span class="channel-metadata">
                     <br/>
-                    <% if !channel.author_handle.nil? %>
-                    <span class="channel-metadata-item"><b><%= channel.author_handle %></b></span>
+                    <% if !channel.channel_handle.nil? %>
+                    <span class="channel-metadata-item"><b><%= channel.channel_handle %></b></span>
                     <span>•</span>
                     <% end %>
                     <% if !channel.pronouns.nil? %><span class="channel-metadata-item"><%= channel.pronouns %></span><% end %>

--- a/src/invidious/views/components/channel_info.ecr
+++ b/src/invidious/views/components/channel_info.ecr
@@ -18,9 +18,11 @@
                     <br/>
                     <% if !channel.channel_handle.nil? %>
                     <span class="channel-metadata-item"><b><%= channel.channel_handle %></b></span>
-                    <span>•</span>
                     <% end %>
-                    <% if !channel.pronouns.nil? %><span class="channel-metadata-item"><%= channel.pronouns %></span><% end %>
+                    <% if !channel.pronouns.nil? %>
+                    <span>•</span>
+                    <span class="channel-metadata-item"><%= channel.pronouns %></span>
+                    <% end %>
                 </span>
             </span>
         </div>

--- a/src/invidious/views/components/channel_info.ecr
+++ b/src/invidious/views/components/channel_info.ecr
@@ -12,10 +12,17 @@
     <div class="pure-u-1-2 flex-left flexible">
         <div class="channel-profile">
             <img src="/ggpht<%= channel_profile_pic %>" alt="" />
-            <div class="channel-name-pronouns">
+            <span class="channel-info">
                 <span class="channel-name"><%= author %></span><% if !channel.verified.nil? && channel.verified %>&nbsp;<i class="icon ion ion-md-checkmark-circle"></i><% end %>
-                <% if !channel.pronouns.nil? %><br /><span class="channel-pronouns"><%= channel.pronouns %></span><% end %>
-            </div>
+                <span class="channel-metadata">
+                    <br/>
+                    <% if !channel.author_handle.nil? %>
+                    <span class="channel-metadata-item"><b><%= channel.author_handle %></b></span>
+                    <span>•</span>
+                    <% end %>
+                    <% if !channel.pronouns.nil? %><span class="channel-metadata-item"><%= channel.pronouns %></span><% end %>
+                </span>
+            </span>
         </div>
     </div>
 


### PR DESCRIPTION
It also fixes some inconsistencies with the CSS and HTML that was introduced in https://github.com/iv-org/invidious/pull/5617 but I didn't really noticed about because it looked fine in the Invidious frontend.

I also added a comment about the `break` statement in the `metadata_rows` row iteration because I didn't get why that `break` was there in the first place.

Closes https://github.com/iv-org/invidious/issues/5638

---

Looks like this in the Invidious frontend (with borders enabled just to see each element sizes and limits):

<img width="256" height="87" alt="image" src="https://github.com/user-attachments/assets/c47e4dec-3428-44c2-9214-ae4db48003b3" />

The API looks like this:

```
  ...
  "author": "Fijxu - Topic",
  "authorHandle": "@Fijxuu",
  "authorId": "UCw-aR42z5gUcarpPGN5OKfA",
  ...
```
