### PR TITLE
Remove noreferer since youtube now requires referers on embeds

### DIFF
--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -125,7 +125,7 @@ we're going to need to do it here in order to allow for translations.
                     end
                 -%>
                 <a id="link-yt-watch" rel="noreferrer noopener" data-base-url="<%= link_yt_watch %>" href="<%= link_yt_watch %>"><%= translate(locale, "videoinfo_watch_on_youTube") %></a>
-                (<a id="link-yt-embed" rel="noopener" data-base-url="<%= link_yt_embed %>" href="<%= link_yt_embed %>"><%= translate(locale, "videoinfo_youTube_embed_link") %></a>)
+                (<a id="link-yt-embed" rel="noopener" referrerpolicy="origin-when-cross-origin" data-base-url="<%= link_yt_embed %>" href="<%= link_yt_embed %>"><%= translate(locale, "videoinfo_youTube_embed_link") %></a>)
             </span>
 
             <p id="watch-on-another-invidious-instance">


### PR DESCRIPTION
Fixes an issue where clicking the embed button resulted in Error 153. YouTube now strictly requires a referrer for embeds to load correctly. This PR updates the link/embed behavior to pass the required referrer, so the embeds now work.

<img width="1918" height="1079" alt="image" src="https://github.com/user-attachments/assets/aa888145-7320-4890-aa20-df826d09fb57" />

 Close https://github.com/iv-org/invidious/issues/5645
 