### PR TITLE
Only include '&' if params are present in `watch` urls for playlist RSS

### DIFF
--- a/src/invidious/routes/feeds.cr
+++ b/src/invidious/routes/feeds.cr
@@ -320,7 +320,7 @@ module Invidious::Routes::Feeds
         case attribute.name
         when "url", "href"
           request_target = URI.parse(node[attribute.name]).request_target
-          query_string_opt = request_target.starts_with?("/watch?v=") ? "&#{params}" : ""
+          query_string_opt = request_target.starts_with?("/watch?v=") ? ("&#{params}" if !params.empty?) : ""
           node[attribute.name] = "#{HOST_URL}#{request_target}#{query_string_opt}"
         else nil # Skip
         end


### PR DESCRIPTION
Related to https://github.com/iv-org/invidious/issues/1232

When passing parameters like `?params=listen%3Dtrue%26quality%3Dmedium` at the end of the feed URL, all videos (`/watch` links) will inherit the passed query parameters, so video links will end up being `/watch?v=<video_id>&listen=true&quality=medium`