### PR TITLE
Add support for alternative domains for Invidious cookies

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -152,6 +152,20 @@ db:
 domain:
 
 ##
+## List of alternative domains where the invidious instance is being served.
+## This needs to be set in order to be able to login and update user preferences
+## when using a domain that is not the same as the `domain` configuration,
+## like a .`onion` address, `.i2p` address, `.b32.i2p` address, etc.
+##
+## It will detect the alternative domain trough the `X-Forwarded-Host` header.
+## https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Host
+##
+## Accepted values: a list of fully qualified domain names (FQDN)
+## Default: <none>
+##
+alternative_domains:
+
+##
 ## Tell Invidious that it is behind a proxy that provides only
 ## HTTPS, so all links must use the https:// scheme. This
 ## setting MUST be set to true if invidious is behind a

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -163,6 +163,12 @@ domain:
 ## Accepted values: a list of fully qualified domain names (FQDN)
 ## Default: <none>
 ##
+## Example:
+## alternative_domains:
+##   - invidious.example.com
+##   - inv.example.com
+##   - videos.example.com
+##
 alternative_domains:
 
 ##

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -120,6 +120,8 @@ class Config
   property hmac_key : String = ""
   # Domain to be used for links to resources on the site where an absolute URL is required
   property domain : String?
+  # Additional domain list that is going to be used for cookie domain validation
+  property alternative_domains : Array(String) = [] of String
   # Subscribe to channels using PubSubHubbub (requires domain, hmac_key)
   property use_pubsub_feeds : Bool | Int32 = false
   property popular_enabled : Bool = true

--- a/src/invidious/routes/before_all.cr
+++ b/src/invidious/routes/before_all.cr
@@ -32,6 +32,8 @@ module Invidious::Routes::BeforeAll
     env.response.headers["X-XSS-Protection"] = "1; mode=block"
     env.response.headers["X-Content-Type-Options"] = "nosniff"
 
+    env.set "header_x-forwarded-host", env.request.headers["X-Forwarded-Host"]?
+
     # Only allow the pages at /embed/* to be embedded
     if env.request.resource.starts_with?("/embed")
       frame_ancestors = "'self' file: http: https:"

--- a/src/invidious/routes/login.cr
+++ b/src/invidious/routes/login.cr
@@ -26,6 +26,7 @@ module Invidious::Routes::Login
 
   def self.login(env)
     locale = env.get("preferences").as(Preferences).locale
+    host = env.get("header_x-forwarded-host")
 
     referer = get_referer(env, "/feed/subscriptions")
 
@@ -57,7 +58,11 @@ module Invidious::Routes::Login
           sid = Base64.urlsafe_encode(Random::Secure.random_bytes(32))
           Invidious::Database::SessionIDs.insert(sid, email)
 
-          env.response.cookies["SID"] = Invidious::User::Cookies.sid(CONFIG.domain, sid)
+          if alt = CONFIG.alternative_domains.index(host)
+            env.response.cookies["SID"] = Invidious::User::Cookies.sid(CONFIG.alternative_domains[alt], sid)
+          else
+            env.response.cookies["SID"] = Invidious::User::Cookies.sid(CONFIG.domain, sid)
+          end
         else
           return error_template(401, "Wrong username or password")
         end
@@ -123,7 +128,11 @@ module Invidious::Routes::Login
         view_name = "subscriptions_#{sha256(user.email)}"
         PG_DB.exec("CREATE MATERIALIZED VIEW #{view_name} AS #{MATERIALIZED_VIEW_SQL.call(user.email)}")
 
-        env.response.cookies["SID"] = Invidious::User::Cookies.sid(CONFIG.domain, sid)
+        if alt = CONFIG.alternative_domains.index(host)
+          env.response.cookies["SID"] = Invidious::User::Cookies.sid(CONFIG.alternative_domains[alt], sid)
+        else
+          env.response.cookies["SID"] = Invidious::User::Cookies.sid(CONFIG.domain, sid)
+        end
 
         if env.request.cookies["PREFS"]?
           user.preferences = env.get("preferences").as(Preferences)

--- a/src/invidious/routes/preferences.cr
+++ b/src/invidious/routes/preferences.cr
@@ -226,7 +226,12 @@ module Invidious::Routes::PreferencesRoute
         File.write("config/config.yml", CONFIG.to_yaml)
       end
     else
-      env.response.cookies["PREFS"] = Invidious::User::Cookies.prefs(CONFIG.domain, preferences)
+      host = env.get("header_x-forwarded-host")
+      if alt = CONFIG.alternative_domains.index(host)
+        env.response.cookies["PREFS"] = Invidious::User::Cookies.prefs(CONFIG.alternative_domains[alt], preferences)
+      else
+        env.response.cookies["PREFS"] = Invidious::User::Cookies.prefs(CONFIG.domain, preferences)
+      end
     end
 
     env.redirect referer
@@ -261,7 +266,12 @@ module Invidious::Routes::PreferencesRoute
         preferences.dark_mode = "dark"
       end
 
-      env.response.cookies["PREFS"] = Invidious::User::Cookies.prefs(CONFIG.domain, preferences)
+      host = env.get("header_x-forwarded-host")
+      if alt = CONFIG.alternative_domains.index(host)
+        env.response.cookies["PREFS"] = Invidious::User::Cookies.prefs(CONFIG.alternative_domains[alt], preferences)
+      else
+        env.response.cookies["PREFS"] = Invidious::User::Cookies.prefs(CONFIG.domain, preferences)
+      end
     end
 
     if redirect

--- a/src/invidious/user/cookies.cr
+++ b/src/invidious/user/cookies.cr
@@ -6,17 +6,24 @@ struct Invidious::User
 
     # Note: we use ternary operator because the two variables
     # used in here are not booleans.
-    SECURE = (Kemal.config.ssl || CONFIG.https_only) ? true : false
+    @@secure = (Kemal.config.ssl || CONFIG.https_only) ? true : false
 
     # Session ID (SID) cookie
     # Parameter "domain" comes from the global config
     def sid(domain : String?, sid) : HTTP::Cookie
+      # Not secure if it's being accessed from I2P
+      # Browsers expect the domain to include https. On I2P there is no HTTPS
+      # Tor browser works fine with secure being true
+      if domain.try &.split(".").last == "i2p"
+        @@secure = false
+      end
+
       return HTTP::Cookie.new(
         name: "SID",
         domain: domain,
         value: sid,
         expires: Time.utc + 2.years,
-        secure: SECURE,
+        secure: @@secure,
         http_only: true,
         samesite: HTTP::Cookie::SameSite::Lax
       )
@@ -25,12 +32,19 @@ struct Invidious::User
     # Preferences (PREFS) cookie
     # Parameter "domain" comes from the global config
     def prefs(domain : String?, preferences : Preferences) : HTTP::Cookie
+      # Not secure if it's being accessed from I2P
+      # Browsers expect the domain to include https. On I2P there is no HTTPS
+      # Tor browser works fine with secure being true
+      if domain.try &.split(".").last == "i2p"
+        @@secure = false
+      end
+
       return HTTP::Cookie.new(
         name: "PREFS",
         domain: domain,
         value: URI.encode_www_form(preferences.to_json),
         expires: Time.utc + 2.years,
-        secure: SECURE,
+        secure: @@secure,
         http_only: false,
         samesite: HTTP::Cookie::SameSite::Lax
       )

--- a/src/invidious/user/cookies.cr
+++ b/src/invidious/user/cookies.cr
@@ -14,7 +14,7 @@ struct Invidious::User
       # Not secure if it's being accessed from I2P
       # Browsers expect the domain to include https. On I2P there is no HTTPS
       # Tor browser works fine with secure being true
-      if domain.try &.split(".").last == "i2p"
+      if (domain.try &.split(".").last == "i2p") && @@secure
         @@secure = false
       end
 
@@ -35,7 +35,7 @@ struct Invidious::User
       # Not secure if it's being accessed from I2P
       # Browsers expect the domain to include https. On I2P there is no HTTPS
       # Tor browser works fine with secure being true
-      if domain.try &.split(".").last == "i2p"
+      if (domain.try &.split(".").last == "i2p") && @@secure
         @@secure = false
       end
 


### PR DESCRIPTION
Closes https://github.com/iv-org/invidious/issues/1421

Adds a new configuration option called `alternative_domains`, a list of additional domains from where the Invidious instance is hosted, this will make hosting Invidious in other domains like Tor hidden services, I2P tunnels, Yggdrasil or any other type of domain that is inserted.

It needs the usage of a reverse proxy to pass the `X-Forwarded-Host` header to Invidious, since that is the header that will be used to detect the alternative domains. It could be more flexible and just use `Host`, in that way, there is no need to use a reverse proxy, but I decided to go with `X-Forwarded-Host` since it's **de-facto standard header for identifying the original host requested by the client in the Host HTTP request header.** (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Host)

Instance administrators will also need to add their additional domains in their reverse proxy configuration, but that will depend on their reverse proxy configuration.

For nginx, that would mean adding the additional domain to their `server_name` server directive, example:


```
  server {
    server_name
           invidious-github.localhost
           someotherdomain.lol
           meowdious.i2p
           superhiddenservicetpm6zs3j4f33elo6wkpbjpxela6uv7hzomeyd.onion
	   ;
    listen 80;
    location / {
      proxy_pass http://127.0.0.1:30001;
      proxy_set_header X-Forwarded-Host $host;
    }
  }
```

Here is a demonstration on how the `Set-Cookie` header looks like when using an alternative domain:

<img width="590" height="160" alt="image" src="https://github.com/user-attachments/assets/0d3f29cf-797e-4885-9479-a7159e332d59" />