### PR TITLE
chore: update Crystal to 1.20.0 in OCI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 ARG OPENSSL_VERSION='3.5.2'
 ARG OPENSSL_SHA256='c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec'
 
-FROM crystallang/crystal:1.16.3-alpine AS dependabot-crystal
+FROM crystallang/crystal:1.20.0-alpine AS dependabot-crystal
 
 # We compile openssl ourselves due to a memory leak in how crystal interacts
 # with openssl
@@ -43,7 +43,7 @@ COPY ./assets/ ./assets/
 COPY ./videojs-dependencies.yml ./videojs-dependencies.yml
 
 RUN crystal spec --warnings all \
-    --link-flags "-lxml2 -llzma"    
+    --link-flags "-lxml2 -llzma"
 
 ARG OPENSSL_VERSION
 COPY --from=openssl-builder /openssl-${OPENSSL_VERSION} /openssl-${OPENSSL_VERSION}

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -2,7 +2,7 @@
 ARG OPENSSL_VERSION='3.5.2'
 ARG OPENSSL_SHA256='c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec'
 
-FROM alpine:3.22 AS dependabot-alpine
+FROM alpine:edge AS dependabot-alpine
 
 # We compile openssl ourselves due to a memory leak in how crystal interacts
 # with openssl
@@ -21,7 +21,7 @@ RUN tar -xzvf openssl-${OPENSSL_VERSION}.tar.gz
 RUN cd openssl-${OPENSSL_VERSION} && ./Configure --openssldir=/etc/ssl && make -j$(nproc)
 
 FROM dependabot-alpine AS builder
-RUN apk add --no-cache 'crystal=1.16.3-r0' shards \
+RUN apk add --no-cache 'crystal=1.20.0-r0' shards \
         sqlite-static yaml-static yaml-dev \
         pcre2-static gc-static \
         libxml2-static zlib-static \
@@ -63,7 +63,7 @@ RUN --mount=type=cache,target=/root/.cache/crystal if [[ "${release}" == 1 ]] ; 
         --link-flags "-lxml2 -llzma"; \
     fi
 
-FROM alpine:3.22
+FROM alpine:3.23
 RUN apk add --no-cache rsvg-convert ttf-opensans tini tzdata
 WORKDIR /invidious
 RUN addgroup -g 1000 -S invidious && \


### PR DESCRIPTION
Supersedes #5690

The memory leak mentioned in the https://github.com/iv-org/invidious/pull/5577 PR seems to be fixed, I have been running my instance using Crystal 1.20.0 for 1 day and memory usage is stable (I use Docker for Invidious and each Invidious container has a hard memory limit of 1536MB, but they barely hit that limit, so the Crystal GC is working fine at freeing memory):

<img height="500" alt="image" src="https://github.com/user-attachments/assets/9e44fc27-832c-4bcc-97ef-19dcb1d648d9" />

