### PR TITLE
chore: lint api/v1/channels.cr

### DIFF
--- a/src/invidious/routes/api/v1/channels.cr
+++ b/src/invidious/routes/api/v1/channels.cr
@@ -128,7 +128,6 @@ module Invidious::Routes::API::V1::Channels
             end
           end
         end # relatedChannels
-
       end
     end
   end


### PR DESCRIPTION
Run `crystal tool format` against codebase using Crystal 1.20.0. 

Fixes linting issues on recent PRs: https://github.com/iv-org/invidious/pull/5692 and https://github.com/iv-org/invidious/pull/5691