### PR TITLE
Fix listen-mode audio quality labels

### DIFF
--- a/spec/invidious/helpers_spec.cr
+++ b/spec/invidious/helpers_spec.cr
@@ -31,6 +31,13 @@ Spectator.describe "Helper" do
     end
   end
 
+  describe "#format_audio_quality_label" do
+    it "formats audio bitrates as readable kilobit labels" do
+      expect(Helpers.format_audio_quality_label(128000)).to eq("128k")
+      expect(Helpers.format_audio_quality_label(50000)).to eq("50k")
+    end
+  end
+
   describe "#sign_token" do
     it "correctly signs a given hash" do
       token = {

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -40,6 +40,10 @@ module Helpers
     return description
   end
 
+  def format_audio_quality_label(bitrate : Int) : String
+    "#{(bitrate / 1000).round.to_i}k"
+  end
+
   def cache_annotation(id, annotations)
     if !CONFIG.cache_annotations
       return

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,12 +28,13 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate = fmt["bitrate"].as_i
+                quality_label = Helpers.format_audio_quality_label(bitrate)
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= quality_label %>" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
## Summary
- formats listen-mode audio stream labels from raw bitrates to readable kilobit values
- keeps the existing `k` label style while showing values like `128k` instead of `128000k`
- adds helper coverage for audio quality label formatting

Fixes #2513

## Testing
- Added spec coverage in `spec/invidious/helpers_spec.cr`
- Not run locally: Crystal is not installed in this execution environment, and Docker/Colima image startup was blocked by network timeouts.

## Bounty
This PR addresses the 0 BTC bounty mentioned in #2513.