### PR TITLE
chore: remove deprecated method `Colorize.on_tty_only!` from Invidious LogHandler

### DIFF
--- a/src/invidious/helpers/logger.cr
+++ b/src/invidious/helpers/logger.cr
@@ -14,7 +14,6 @@ end
 class Invidious::LogHandler < Kemal::BaseLogHandler
   def initialize(@io : IO = STDOUT, @level = LogLevel::Debug, use_color : Bool = true)
     Colorize.enabled = use_color
-    Colorize.on_tty_only!
   end
 
   def call(context : HTTP::Server::Context)


### PR DESCRIPTION
This method has been the default since Crystal 1.17.0: https://github.com/crystal-lang/crystal/pull/15881

Is going to get deprecated when Crystal 1.21.0 is released: https://github.com/crystal-lang/crystal/pull/16859

This should only be merged if we only want to support 1.17.0 and up as is not a critical thing we have to fix, so this PR can wait until we deprecate Crystal <1.17.0