### PR TITLE
chore: replace deprecated argument `writeable` to `writable` in IO::Memory.new()

### DIFF
--- a/src/invidious/http_server/static_assets_handler.cr
+++ b/src/invidious/http_server/static_assets_handler.cr
@@ -82,7 +82,7 @@ module Invidious::HttpServer
     private def dispatch_serve(context, file, file_info, range_header)
       if range_header
         # an IO is needed for `serve_file_range`
-        file = file.is_a?(Bytes) ? IO::Memory.new(file, writeable: false) : file
+        file = file.is_a?(Bytes) ? IO::Memory.new(file, writable: false) : file
         serve_file_range(context, file, range_header, file_info)
       else
         context.response.headers["Accept-Ranges"] = "bytes"


### PR DESCRIPTION
Crystal 1.21.0 replaces `IO::Memory.new` argument `writeable` to `writable`: https://github.com/crystal-lang/crystal/pull/16858

This PR can wait until we no longer support Crystal <1.21.0

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the `IO::Memory` keyword used to wrap cached static-file bytes for Crystal 1.21.0 compatibility. The potential cached byte-range regression was disproved: the focused static-assets tests passed all 8 examples, including caching a file from an initial range request and serving later ranges from cached bytes. Direct runtime checks also confirmed that the updated constructor remains read-only: reads succeed and writes raise `IO::Error`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge based on the exercised cached static-file range behavior.

The updated Crystal 1.21.0 constructor compiled and retained the prior read-only behavior, while focused runtime coverage passed for cached responses, byte ranges, multipart ranges, compression, and cache limits.

**Files Needing Attention:** No files need further attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Crystal 1.21.0 review harness to compare IO::Memory.new(bytes, writeable: false) with IO::Memory.new(bytes, writable: false) and executed the static assets handler spec with -Drunning\_by\_self.
- Validated that both constructor forms read cached bytes and reject writes with IO::Error, confirming the updated keyword preserves the checked cached byte-range behavior.
- Collected the evidence artifacts showing baseline and PR behavior, including the authored evidence harness script.

<a href="https://app.greptile.com/trex/runs/19165009/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: replace deprecated argument \`writ..."](https://github.com/iv-org/invidious/commit/96b8f69d33782ffcac1ee248088ba0808ce8addc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53891112)</sub>

<!-- /greptile_comment -->