### PR TITLE
feat: add option to filter Shorts / videos under 1 minute (#5688)

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -104,6 +104,7 @@
     "preferences_captions_label": "Default captions: ",
     "Fallback captions: ": "Fallback captions: ",
     "preferences_related_videos_label": "Show related videos: ",
+    "preferences_filter_short_videos_label": "Hide Shorts / videos under 1 minute: ",
     "preferences_annotations_label": "Show annotations by default: ",
     "preferences_extend_desc_label": "Automatically extend video description: ",
     "preferences_vr_mode_label": "Interactive 360 degree videos (requires WebGL): ",

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -48,6 +48,7 @@ struct ConfigPreferences
   property unseen_only : Bool = false
   property video_loop : Bool = false
   property extend_desc : Bool = false
+  property filter_short_videos : Bool = false
   property volume : Int32 = 100
   property vr_mode : Bool = true
   property show_nick : Bool = true

--- a/src/invidious/routes/search.cr
+++ b/src/invidious/routes/search.cr
@@ -63,6 +63,10 @@ module Invidious::Routes::Search
         else
           items = query.process
         end
+
+        if preferences.filter_short_videos
+          items = items.reject { |item| item.is_a?(SearchVideo) && item.as(SearchVideo).length_seconds < 60 }
+        end
       rescue ex : ChannelSearchException
         return error_template(404, "Unable to find channel with id of '#{HTML.escape(ex.channel)}'. Are you sure that's an actual channel id? It should look like 'UC4QobU6STFB0P71PMvOGN5A'.")
       rescue ex

--- a/src/invidious/search/processors.cr
+++ b/src/invidious/search/processors.cr
@@ -39,7 +39,7 @@ module Invidious::Search
     def subscriptions(query : Query, user : Invidious::User) : Array(ChannelVideo)
       view_name = "subscriptions_#{sha256(user.email)}"
 
-      return PG_DB.query_all("
+      videos = PG_DB.query_all("
         SELECT id,title,published,updated,ucid,author,length_seconds
         FROM (
           SELECT *,
@@ -51,6 +51,12 @@ module Invidious::Search
         query.text, (query.page - 1) * 20,
         as: ChannelVideo
       )
+
+      if user.preferences.filter_short_videos
+        videos = videos.reject { |v| v.length_seconds < 60 }
+      end
+
+      return videos
     end
   end
 end

--- a/src/invidious/user/preferences.cr
+++ b/src/invidious/user/preferences.cr
@@ -54,6 +54,7 @@ struct Preferences
   property unseen_only : Bool = CONFIG.default_user_preferences.unseen_only
   property video_loop : Bool = CONFIG.default_user_preferences.video_loop
   property extend_desc : Bool = CONFIG.default_user_preferences.extend_desc
+  property filter_short_videos : Bool = CONFIG.default_user_preferences.filter_short_videos
   property volume : Int32 = CONFIG.default_user_preferences.volume
   property save_player_pos : Bool = CONFIG.default_user_preferences.save_player_pos
   property default_playlist : String? = nil

--- a/src/invidious/users.cr
+++ b/src/invidious/users.cr
@@ -102,5 +102,10 @@ def get_subscription_feed(user, max_results = 40, page = 1)
     videos = videos - notifications
   end
 
+  if user.preferences.filter_short_videos
+    videos = videos.reject { |v| v.length_seconds < 60 }
+    notifications = notifications.reject { |v| v.length_seconds < 60 }
+  end
+
   return videos, notifications
 end

--- a/src/invidious/views/user/preferences.ecr
+++ b/src/invidious/views/user/preferences.ecr
@@ -107,6 +107,11 @@
             </div>
 
             <div class="pure-control-group">
+                <label for="filter_short_videos"><%= I18n.translate(locale, "preferences_filter_short_videos_label") %></label>
+                <input name="filter_short_videos" id="filter_short_videos" type="checkbox" <% if preferences.filter_short_videos %>checked<% end %>>
+            </div>
+
+            <div class="pure-control-group">
                 <label for="annotations"><%= I18n.translate(locale, "preferences_annotations_label") %></label>
                 <input name="annotations" id="annotations" type="checkbox" <% if preferences.annotations %>checked<% end %>>
             </div>


### PR DESCRIPTION
## Summary
Adds a user preference to hide YouTube Shorts / videos under 1 minute from subscription feeds and search results.

## Changes
- Added `filter_short_videos` boolean preference (default: false)
- Filters out videos with `length_seconds < 60` when preference is enabled
- Added checkbox in user preferences UI: "Hide Shorts / videos under 1 minute"

## Related
Closes #5688