### PR TITLE
CI: update Crystal 1.20.0 to 1.20.1 in ci.yml matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           - 1.17.1
           - 1.18.2
           - 1.19.2
-          - 1.20.0
+          - 1.20.1
         include:
           - crystal: nightly
             stable: false


### PR DESCRIPTION
1.20.1 released: https://github.com/crystal-lang/crystal/releases/tag/1.20.1