### PR TITLE
Clarify listen mode audio quality labels

### DIFF
--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,12 +28,12 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate = fmt["bitrate"].as_i // 1000
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %> kbps" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
Fixes #2513.

## Summary
- Convert listen-mode audio bitrate labels from raw bits per second to kbps.
- Display the unit as `kbps` so the quality selector is easier to understand.

## Testing
- Ran `git diff --check origin/master...HEAD` locally.
- Full Crystal specs were not run because Crystal/Docker are not available in my local environment.

This PR was prepared with AI assistance under the Dexterqo account.