### PR TITLE
[codex] Show message when YouTube comments are disabled

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -236,6 +236,7 @@
     "This channel does not exist.": "This channel does not exist.",
     "Could not get channel info.": "Could not get channel info.",
     "Could not fetch comments": "Could not fetch comments",
+    "Comments are turned off.": "Comments are turned off.",
     "comments_view_x_replies": "View {{count}} reply",
     "comments_view_x_replies_plural": "View {{count}} replies",
     "`x` ago": "`x` ago",

--- a/spec/invidious/comments/youtube_spec.cr
+++ b/spec/invidious/comments/youtube_spec.cr
@@ -1,0 +1,57 @@
+require "../../parsers_helper"
+require "../../../src/invidious/helpers/helpers"
+require "../../../src/invidious/helpers/i18next"
+require "../../../src/invidious/helpers/i18n"
+require "../../../src/invidious/yt_backend/youtube_api"
+require "../../../src/invidious/frontend/comments_youtube"
+require "../../../src/invidious/comments/youtube"
+
+Spectator.describe Invidious::Comments do
+  describe ".parse_youtube" do
+    it "shows a message when comments are disabled" do
+      response = JSON.parse({
+        "onResponseReceivedEndpoints" => [
+          {
+            "reloadContinuationItemsCommand" => {
+              "slot"              => "RELOAD_CONTINUATION_SLOT_HEADER",
+              "continuationItems" => [
+                {
+                  "commentsHeaderRenderer" => {
+                    "countText" => {"simpleText" => "0 Comments"},
+                  },
+                },
+              ],
+            },
+          },
+          {
+            "reloadContinuationItemsCommand" => {
+              "slot" => "RELOAD_CONTINUATION_SLOT_BODY",
+            },
+          },
+        ],
+      }.to_json)
+
+      parsed = JSON.parse(Invidious::Comments.parse_youtube("video-id", response, "html", "en-US", false))
+
+      expect(parsed["contentHtml"].as_s).to contain("Comments are turned off.")
+      expect(parsed["commentCount"].as_i).to eq(0)
+    end
+
+    it "marks disabled comments in JSON responses" do
+      response = JSON.parse({
+        "onResponseReceivedEndpoints" => [
+          {
+            "reloadContinuationItemsCommand" => {
+              "slot" => "RELOAD_CONTINUATION_SLOT_BODY",
+            },
+          },
+        ],
+      }.to_json)
+
+      parsed = JSON.parse(Invidious::Comments.parse_youtube("video-id", response, "json", "en-US", false))
+
+      expect(parsed["comments"].as_a).to be_empty
+      expect(parsed["commentsDisabled"].as_bool).to be_true
+    end
+  end
+end

--- a/src/invidious/comments/youtube.cr
+++ b/src/invidious/comments/youtube.cr
@@ -94,9 +94,13 @@ module Invidious::Comments
 
     if !contents
       if format == "json"
-        return {"comments" => [] of String}.to_json
+        return {
+          "comments"         => [] of String,
+          "commentsDisabled" => true,
+        }.to_json
       else
-        return {"contentHtml" => "", "commentCount" => 0}.to_json
+        message = HTML.escape(I18n.translate(locale, "Comments are turned off."))
+        return {"contentHtml" => "<p>#{message}</p>", "commentCount" => 0}.to_json
       end
     end
 


### PR DESCRIPTION
Fixes #1092.

## Changes
- Return a localized "Comments are turned off." message when YouTube provides no comment continuation items.
- Add `commentsDisabled: true` to the JSON response for the same case.
- Add regression coverage for both HTML and JSON parser output.

## Validation
- `crystal tool format --check src/invidious/comments/youtube.cr spec/invidious/comments/youtube_spec.cr`
- `make verify`
- `crystal spec spec/invidious/comments/youtube_spec.cr --warnings all`
- `crystal spec --warnings all`