### PR TITLE
Fallback from DASH on iPhone and iPod

### DIFF
--- a/spec/invidious/helpers_spec.cr
+++ b/spec/invidious/helpers_spec.cr
@@ -53,4 +53,30 @@ Spectator.describe "Helper" do
       expect(sign_token("SECRET_KEY", token)).to eq(token["signature"])
     end
   end
+
+  describe "#user_agent_lacks_dash_support?" do
+    it "detects iPhone Safari" do
+      user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Mobile/15E148 Safari/604.1"
+
+      expect(user_agent_lacks_dash_support?(user_agent)).to be_true
+    end
+
+    it "detects iPod Safari" do
+      user_agent = "Mozilla/5.0 (iPod touch; CPU iPhone OS 15_8 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.8 Mobile/15E148 Safari/604.1"
+
+      expect(user_agent_lacks_dash_support?(user_agent)).to be_true
+    end
+
+    it "does not force the fallback on iPad or desktop Safari" do
+      ipad_user_agent = "Mozilla/5.0 (iPad; CPU OS 17_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Mobile/15E148 Safari/604.1"
+      mac_user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15"
+
+      expect(user_agent_lacks_dash_support?(ipad_user_agent)).to be_false
+      expect(user_agent_lacks_dash_support?(mac_user_agent)).to be_false
+    end
+
+    it "does not force the fallback without a user agent" do
+      expect(user_agent_lacks_dash_support?(nil)).to be_false
+    end
+  end
 end

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -202,6 +202,12 @@ def number_to_short_text(number)
   text
 end
 
+def user_agent_lacks_dash_support?(user_agent : String?) : Bool
+  return false if user_agent.nil?
+
+  user_agent.includes?("iPhone") || user_agent.includes?("iPod")
+end
+
 def arg_array(array, start = 1)
   if array.size == 0
     args = "NULL"

--- a/src/invidious/routes/embed.cr
+++ b/src/invidious/routes/embed.cr
@@ -123,6 +123,9 @@ module Invidious::Routes::Embed
     end
 
     params = process_video_params(env.params.query, preferences)
+    if params.quality == "dash" && user_agent_lacks_dash_support?(env.request.headers["User-Agent"]?)
+      params.quality = "hd720"
+    end
 
     user = env.get?("user").try &.as(User)
     if user

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -48,6 +48,9 @@ module Invidious::Routes::Watch
     subscriptions ||= [] of String
 
     params = process_video_params(env.params.query, preferences)
+    if params.quality == "dash" && user_agent_lacks_dash_support?(env.request.headers["User-Agent"]?)
+      params.quality = "hd720"
+    end
     env.params.query.delete_all("listen")
 
     begin


### PR DESCRIPTION
Fixes #2236.

## Summary
- Detect iPhone and iPod user agents, which do not support DASH/MSE playback in Safari/WebKit.
- When those clients request `quality=dash`, use the existing muxed `hd720` source path for watch and embed pages.
- Leave iPad and desktop Safari on the current DASH path.

## Testing
- `crystal tool format --check src/invidious/helpers/utils.cr src/invidious/routes/watch.cr src/invidious/routes/embed.cr spec/invidious/helpers_spec.cr`
- `make verify`
- `crystal spec --warnings all`
