### PR TITLE
Fix empty query separator in playlist RSS links

### DIFF
--- a/spec/invidious/routes/feeds_spec.cr
+++ b/spec/invidious/routes/feeds_spec.cr
@@ -1,0 +1,26 @@
+require "../../spec_helper"
+
+Spectator.describe "Feeds" do
+  describe "#add_video_query_params" do
+    it "does not append an empty query separator" do
+      request_target = "/watch?v=7uQOBLCcp3I"
+      params = HTTP::Params.parse("")
+
+      expect(add_video_query_params(request_target, params)).to eq(request_target)
+    end
+
+    it "appends non-empty params to watch links" do
+      request_target = "/watch?v=7uQOBLCcp3I"
+      params = HTTP::Params.parse("listen=1")
+
+      expect(add_video_query_params(request_target, params)).to eq("#{request_target}&listen=1")
+    end
+
+    it "leaves non-watch links unchanged" do
+      request_target = "/vi/7uQOBLCcp3I/hqdefault.jpg"
+      params = HTTP::Params.parse("listen=1")
+
+      expect(add_video_query_params(request_target, params)).to eq(request_target)
+    end
+  end
+end

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -273,6 +273,15 @@ def get_referer(env, fallback = "/", unroll = true)
   return referer
 end
 
+def add_video_query_params(request_target : String, params : HTTP::Params) : String
+  params = params.to_s
+
+  return request_target unless request_target.starts_with?("/watch?v=")
+  return request_target if params.empty?
+
+  "#{request_target}&#{params}"
+end
+
 def sha256(text)
   digest = OpenSSL::Digest.new("SHA256")
   digest << text

--- a/src/invidious/routes/feeds.cr
+++ b/src/invidious/routes/feeds.cr
@@ -320,8 +320,7 @@ module Invidious::Routes::Feeds
         case attribute.name
         when "url", "href"
           request_target = URI.parse(node[attribute.name]).request_target
-          query_string_opt = request_target.starts_with?("/watch?v=") ? "&#{params}" : ""
-          node[attribute.name] = "#{HOST_URL}#{request_target}#{query_string_opt}"
+          node[attribute.name] = "#{HOST_URL}#{add_video_query_params(request_target, params)}"
         else nil # Skip
         end
       end


### PR DESCRIPTION
## Summary
- avoid appending an empty query separator to proxied playlist RSS watch links
- keep non-empty feed params on watch links and leave thumbnails/non-watch URLs unchanged
- add focused regression coverage for empty and non-empty params

Fixes #1232.

## Testing
- Not run locally: Crystal is not installed in this environment, and Docker Desktop is not running.