### PR TITLE
Fix stray ampersand in playlist RSS links

### DIFF
--- a/src/invidious/routes/feeds.cr
+++ b/src/invidious/routes/feeds.cr
@@ -320,7 +320,7 @@ module Invidious::Routes::Feeds
         case attribute.name
         when "url", "href"
           request_target = URI.parse(node[attribute.name]).request_target
-          query_string_opt = request_target.starts_with?("/watch?v=") ? "&#{params}" : ""
+          query_string_opt = (!params.empty? && request_target.starts_with?("/watch?v=")) ? "&#{params}" : ""
           node[attribute.name] = "#{HOST_URL}#{request_target}#{query_string_opt}"
         else nil # Skip
         end


### PR DESCRIPTION
Fixes #1232

This keeps the change in the existing RSS link rewrite path and only appends serialized params when params are present. That removes the stray trailing `&` from playlist RSS watch links while preserving the current behavior when feed params actually exist.

AI assistance disclosure: this PR was prepared with AI assistance, then manually reviewed and verified in an isolated Quilt sandbox with a repo-native compile check.
