### PR TITLE
Fix listen mode audio bitrate labels

### DIFF
--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -164,8 +164,13 @@ module Invidious::Routes::Watch
         url = audio_streams[0]["url"].as_s
 
         if params.quality.ends_with? "k"
+          requested_bitrate = params.quality.rchop("k").to_i
+
           audio_streams.each do |fmt|
-            if fmt["bitrate"].as_i == params.quality.rchop("k").to_i
+            bitrate = fmt["bitrate"].as_i
+            bitrate_k = bitrate // 1000
+
+            if bitrate_k == requested_bitrate || bitrate == requested_bitrate
               url = fmt["url"].as_s
             end
           end

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,7 +28,7 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate = fmt["bitrate"].as_i // 1000
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)


### PR DESCRIPTION
Closes #2513

## Summary
- Show listen-mode audio quality labels in kbps instead of raw bit/s values, so entries like `100000k` become normal labels such as `100k`.
- Keep raw-mode audio quality selection compatible with both the new kbps labels and old raw-bitrate `k` query values.

## Verification
- Static source review of the listen-mode `<source label>` generation path in `src/invidious/views/components/player.ecr`.
- Static source review of the matching raw audio quality branch in `src/invidious/routes/watch.cr`.

I could not run the Crystal test suite locally because `crystal`, `shards`, and Docker are not available in this Windows environment.