### PR TITLE
fix: prevent trailing & in playlist RSS feed watch links (#1232)

### DIFF
--- a/src/invidious/routes/feeds.cr
+++ b/src/invidious/routes/feeds.cr
@@ -320,7 +320,7 @@ module Invidious::Routes::Feeds
         case attribute.name
         when "url", "href"
           request_target = URI.parse(node[attribute.name]).request_target
-          query_string_opt = request_target.starts_with?("/watch?v=") ? "&#{params}" : ""
+          query_string_opt = request_target.starts_with?("/watch?v=") && !params.empty? ? "&#{params}" : ""
           node[attribute.name] = "#{HOST_URL}#{request_target}#{query_string_opt}"
         else nil # Skip
         end


### PR DESCRIPTION
## Summary
Fix for BOUNTY USD 10 - Playlist RSS feeds URLs end with "&" - Issue #1232

## Root cause
In src/invidious/routes/feeds.cr, the rss_playlist function was appending params to watch links unconditionally when the URL started with /watch?v=. When params was empty, this resulted in a trailing & character being appended to URLs.

## Fix
Added check !params.empty? to only append params when non-empty.

## Verification
Before: href="https://example.com/watch?v=VIDEO_ID&"
After: href="https://example.com/watch?v=VIDEO_ID" (no trailing &)

Closes #1232