### PR TITLE
Fix listen mode audio quality labels

### DIFF
--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -164,8 +164,10 @@ module Invidious::Routes::Watch
         url = audio_streams[0]["url"].as_s
 
         if params.quality.ends_with? "k"
+          quality_bitrate = params.quality.rchop("k").to_i
           audio_streams.each do |fmt|
-            if fmt["bitrate"].as_i == params.quality.rchop("k").to_i
+            bitrate = fmt["bitrate"].as_i
+            if bitrate == quality_bitrate || bitrate / 1000 == quality_bitrate
               url = fmt["url"].as_s
             end
           end

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,12 +28,13 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate = fmt["bitrate"].as_i
+                bitrate_kbps = bitrate / 1000
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate_kbps %>k" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
Fixes #2513.

Listen-mode audio sources were labeled with the raw `bitrate` value plus `k`, so a 128 kbps stream could appear as `128000k` in the quality selector.

This PR:
- converts listen-mode audio source labels from bits per second to kbps before appending `k`
- keeps raw listen-mode `quality=` selection compatible with both the previous raw-bitrate value and the corrected kbps value

Verification with Crystal 1.20.1:
- `git submodule update --init --recursive mocks`
- `shards install`
- `crystal spec` -> 164 examples, 0 failures
- `crystal build src/invidious.cr -Dskip_videojs_download --no-codegen --warnings all --error-on-warnings --progress --stats --error-trace` -> passed