### PR TITLE
Fix: clarify listen mode audio quality labels

### DIFF
--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,12 +28,13 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate = fmt["bitrate"].as_i
+                bitrate_kbps = (bitrate / 1000).round.to_i
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate_kbps %> kbps audio" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
## Summary
- Clarifies listen-mode adaptive audio labels by including the bitrate in kbps.
- Keeps the MIME type visible in the source metadata so users can distinguish audio options more easily.

## Test Plan
- Ran `git diff --check`.
- Crystal is not installed in this local environment, so I could not run the full project test suite here.

Closes #2513
