### PR TITLE
Fix audio quality labels

### DIFF
--- a/spec/invidious/helpers_spec.cr
+++ b/spec/invidious/helpers_spec.cr
@@ -53,4 +53,12 @@ Spectator.describe "Helper" do
       expect(sign_token("SECRET_KEY", token)).to eq(token["signature"])
     end
   end
+
+  describe "#format_audio_quality_label" do
+    it "formats audio bitrates as readable kilobit labels" do
+      expect(Helpers.format_audio_quality_label(JSON::Any.new(128000_i64))).to eq("128k")
+      expect(Helpers.format_audio_quality_label(JSON::Any.new("50000"))).to eq("50k")
+      expect(Helpers.format_audio_quality_label(JSON::Any.new(nil))).to eq("0k")
+    end
+  end
 end

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -203,4 +203,9 @@ module Helpers
 
     return tracker.as(Hash(String, Int64 | Float64))
   end
+
+  def format_audio_quality_label(bitrate : JSON::Any) : String
+    val = bitrate.as_i? || bitrate.as_s?.try(&.to_i?) || 0
+    "#{(val / 1000).round.to_i}k"
+  end
 end

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -29,11 +29,12 @@
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
                 bitrate = fmt["bitrate"]
+                quality_label = Helpers.format_audio_quality_label(bitrate)
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= quality_label %>" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
Fixes #2513

## Summary
- Formats listen-mode audio stream labels from raw bitrates (e.g. `128000k`) to human-readable kilobit values (e.g. `128k`) safely.
- Uses a safe type-checking helper method to prevent runtime crashes (500 errors) in case the API returns string-based bitrates.
- Adds comprehensive unit tests for the helper method.
I want to be awarded the bounty associated to the issue this PR is fixing.



/claim #2513