### PR TITLE
Fix listen mode audio quality labels

### DIFF
--- a/spec/invidious/utils_spec.cr
+++ b/spec/invidious/utils_spec.cr
@@ -43,4 +43,27 @@ Spectator.describe "Utils" do
       expect(decode_date("8 years ago")).to be_close(Time.utc - 8.years, 500.milliseconds)
     end
   end
+
+  describe "audio_bitrate_label" do
+    it "formats audio bitrates in kbps" do
+      expect(audio_bitrate_label(100_000)).to eq("100k")
+      expect(audio_bitrate_label(128_000)).to eq("128k")
+      expect(audio_bitrate_label(129_600)).to eq("130k")
+    end
+  end
+
+  describe "audio_quality_param_matches?" do
+    it "matches legacy raw-bitrate quality params" do
+      expect(audio_quality_param_matches?("128000k", 128_000)).to be_true
+    end
+
+    it "matches kbps quality params from the player label" do
+      expect(audio_quality_param_matches?("128k", 128_000)).to be_true
+    end
+
+    it "ignores non-audio quality params" do
+      expect(audio_quality_param_matches?("hd720", 128_000)).to be_false
+      expect(audio_quality_param_matches?("invalidk", 128_000)).to be_false
+    end
+  end
 end

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -202,6 +202,23 @@ def number_to_short_text(number)
   text
 end
 
+def audio_bitrate_kbps(bitrate)
+  ((bitrate + 500) // 1000).to_i
+end
+
+def audio_bitrate_label(bitrate)
+  "#{audio_bitrate_kbps(bitrate)}k"
+end
+
+def audio_quality_param_matches?(quality : String, bitrate)
+  return false unless quality.ends_with?("k")
+
+  requested_bitrate = quality.rchop("k").to_i?
+  return false if requested_bitrate.nil?
+
+  bitrate == requested_bitrate || audio_bitrate_kbps(bitrate) == requested_bitrate
+end
+
 def arg_array(array, start = 1)
   if array.size == 0
     args = "NULL"

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -163,11 +163,11 @@ module Invidious::Routes::Watch
       if params.listen
         url = audio_streams[0]["url"].as_s
 
-        if params.quality.ends_with? "k"
-          audio_streams.each do |fmt|
-            if fmt["bitrate"].as_i == params.quality.rchop("k").to_i
-              url = fmt["url"].as_s
-            end
+        audio_streams.each do |fmt|
+          bitrate = fmt["bitrate"].as_i
+
+          if audio_quality_param_matches?(params.quality, bitrate)
+            url = fmt["url"].as_s
           end
         end
       else

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,12 +28,13 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate = fmt["bitrate"].as_i
+                bitrate_label = audio_bitrate_label(bitrate)
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate_label %>" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
Fixes #2513.

Summary:
- Display listen-mode audio stream labels as kbps, e.g. 128k, instead of raw bps values like 128000k.
- Keep raw audio quality selection compatible with both legacy 128000k params and displayed 128k labels.
- Add utility coverage for audio bitrate label formatting and matching.

Tests:
- Docker: crystal spec spec/invidious/utils_spec.cr --warnings all --link-flags "-lxml2 -llzma"

If accepted for the BTC bounty, payout details can be coordinated privately.