### PR TITLE
fix: fix `Missing hash key: "collectionThumbnailViewModel"`

### DIFF
--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -651,8 +651,7 @@ private module Parsers
       playlist_id = item_contents["contentId"].as_s
 
       thumbnail_view_model = item_contents.dig(
-        "contentImage", "collectionThumbnailViewModel",
-        "primaryThumbnail", "thumbnailViewModel"
+        "contentImage", "thumbnailViewModel"
       )
 
       thumbnail = thumbnail_view_model.dig("image", "sources", 0, "url").as_s


### PR DESCRIPTION
Now the Innertube structure doesn't include `collectionThumbnailViewModel` and `primaryThumbnail` keys.

Now the structure looks like this:
```
"horizontalListRenderer": {
    "items": [
        {
            "lockupViewModel": {
                "contentImage": {
                    "thumbnailViewModel": {
                        "image": {
                            "sources": []
...
```

Fixes: https://github.com/iv-org/invidious/issues/5516