### PR TITLE
Fix listen mode audio bitrate labels

### DIFF
--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -164,9 +164,13 @@ module Invidious::Routes::Watch
         url = audio_streams[0]["url"].as_s
 
         if params.quality.ends_with? "k"
+          requested_audio_bitrate = params.quality.rchop("k").to_i?
           audio_streams.each do |fmt|
-            if fmt["bitrate"].as_i == params.quality.rchop("k").to_i
-              url = fmt["url"].as_s
+            if requested_audio_bitrate
+              bitrate = fmt["bitrate"].as_i
+              if (bitrate / 1000).round.to_i == requested_audio_bitrate || bitrate == requested_audio_bitrate
+                url = fmt["url"].as_s
+              end
             end
           end
         end

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -14,11 +14,17 @@
             <% # default to 128k m4a stream
                best_m4a_stream_index = 0
                best_m4a_stream_bitrate = 0
+               requested_audio_bitrate = params.quality.ends_with?("k") ? params.quality.rchop("k").to_i? : nil
                audio_streams.each_with_index do |fmt, i|
                  bandwidth = fmt["bitrate"].as_i
                  if (fmt["mimeType"].as_s.starts_with?("audio/mp4") && bandwidth > best_m4a_stream_bitrate)
                    best_m4a_stream_bitrate = bandwidth
                    best_m4a_stream_index = i
+                 end
+                 if requested_audio_bitrate
+                   if (bandwidth / 1000).round.to_i == requested_audio_bitrate || bandwidth == requested_audio_bitrate
+                     best_m4a_stream_index = i
+                   end
                  end
                end
 
@@ -28,7 +34,7 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate = (fmt["bitrate"].as_i / 1000).round.to_i
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)


### PR DESCRIPTION
Fixes #2513

This updates listen-mode audio source labels to display bitrate in kbps instead of appending `k` to YouTube's raw bits-per-second value. For example, a `128000` bps audio stream now appears as `128k` instead of `128000k`.

The raw listen route now accepts the kbps-style quality value while still accepting the old raw bitrate value for backwards compatibility.

I refreshed the branch onto current upstream `master` after the earlier closure so the PR remains current while still only changing the two relevant files.

Validation:
- `shards install`
- `crystal build src/invidious.cr --no-codegen`
- `crystal tool format --check src/invidious/routes/watch.cr`
- `git diff --check upstream/master..HEAD`

Bounty note: this PR addresses the `$10` bounty on #2513. Payment details can be provided privately if accepted.
