### PR TITLE
Add support for `/pl_c`  and `/tvfilm_banner` paths (thumbnails used in some playlists)

### DIFF
--- a/src/invidious/routes/images.cr
+++ b/src/invidious/routes/images.cr
@@ -51,7 +51,7 @@ module Invidious::Routes::Images
   end
 
   # ??? maybe also for storyboards?
-  def self.s_p_image(env)
+  def self.s_p_image(env, authority = "i9")
     id = env.params.url["id"]
     name = env.params.url["name"]
     url = env.request.resource
@@ -65,11 +65,21 @@ module Invidious::Routes::Images
     end
 
     begin
-      get_ytimg_pool("i9").client &.get(url, headers) do |resp|
+      get_ytimg_pool(authority).client &.get(url, headers) do |resp|
         return self.proxy_image(env, resp)
       end
     rescue ex
     end
+  end
+
+  # Both pl_c and tvfilm_banner use the same logic used in s_p_image(env)
+  # just with a different authority ("i").
+  def self.pl_c_image(env)
+    self.s_p_image(env, "i")
+  end
+
+  def self.tvfilm_banner_image(env)
+    self.s_p_image(env, "i")
   end
 
   def self.yts_image(env)

--- a/src/invidious/routes/images.cr
+++ b/src/invidious/routes/images.cr
@@ -134,6 +134,27 @@ module Invidious::Routes::Images
     end
   end
 
+  def self.pl_c_image(env)
+    id = env.params.url["id"]
+    name = env.params.url["name"]
+    url = env.request.resource
+
+    headers = HTTP::Headers.new
+
+    REQUEST_HEADERS_WHITELIST.each do |header|
+      if env.request.headers[header]?
+        headers[header] = env.request.headers[header]
+      end
+    end
+
+    begin
+      get_ytimg_pool("i").client &.get(url, headers) do |resp|
+        return self.proxy_image(env, resp)
+      end
+    rescue ex
+    end
+  end
+
   private def self.proxy_image(env, response)
     env.response.status_code = response.status_code
     response.headers.each do |key, value|

--- a/src/invidious/routes/images.cr
+++ b/src/invidious/routes/images.cr
@@ -134,27 +134,6 @@ module Invidious::Routes::Images
     end
   end
 
-  def self.pl_c_image(env)
-    id = env.params.url["id"]
-    name = env.params.url["name"]
-    url = env.request.resource
-
-    headers = HTTP::Headers.new
-
-    REQUEST_HEADERS_WHITELIST.each do |header|
-      if env.request.headers[header]?
-        headers[header] = env.request.headers[header]
-      end
-    end
-
-    begin
-      get_ytimg_pool("i").client &.get(url, headers) do |resp|
-        return self.proxy_image(env, resp)
-      end
-    rescue ex
-    end
-  end
-
   private def self.proxy_image(env, response)
     env.response.status_code = response.status_code
     response.headers.each do |key, value|

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -222,7 +222,6 @@ module Invidious::Routing
     get "/s_p/:id/:name", Routes::Images, :s_p_image
     get "/yts/img/:name", Routes::Images, :yts_image
     get "/vi/:id/:name", Routes::Images, :thumbnails
-    # Both pl_c and tvfilm_banner use the same logic used in s_p_image(env)
     get "/pl_c/:id/:name", Routes::Images, :pl_c_image
     get "/tvfilm_banner/:id/:name", Routes::Images, :tvfilm_banner_image
   end

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -223,8 +223,8 @@ module Invidious::Routing
     get "/yts/img/:name", Routes::Images, :yts_image
     get "/vi/:id/:name", Routes::Images, :thumbnails
     # Both pl_c and tvfilm_banner use the same logic used in s_p_image(env)
-    get "/pl_c/:id/:name", Routes::Images, :s_p_image
-    get "/tvfilm_banner/:id/:name", Routes::Images, :s_p_image
+    get "/pl_c/:id/:name", Routes::Images, :pl_c_image
+    get "/tvfilm_banner/:id/:name", Routes::Images, :tvfilm_banner_image
   end
 
   def register_companion_routes

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -222,7 +222,9 @@ module Invidious::Routing
     get "/s_p/:id/:name", Routes::Images, :s_p_image
     get "/yts/img/:name", Routes::Images, :yts_image
     get "/vi/:id/:name", Routes::Images, :thumbnails
-    get "/pl_c/:id/:name", Routes::Images, :pl_c_image
+    # Both pl_c and tvfilm_banner use the same logic used in s_p_image(env)
+    get "/pl_c/:id/:name", Routes::Images, :s_p_image
+    get "/tvfilm_banner/:id/:name", Routes::Images, :s_p_image
   end
 
   def register_companion_routes

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -222,6 +222,7 @@ module Invidious::Routing
     get "/s_p/:id/:name", Routes::Images, :s_p_image
     get "/yts/img/:name", Routes::Images, :yts_image
     get "/vi/:id/:name", Routes::Images, :thumbnails
+    get "/pl_c/:id/:name", Routes::Images, :pl_c_image
   end
 
   def register_companion_routes


### PR DESCRIPTION
This path can be found on Podcast images and this PR fixes images for that type of thumbnails:

Podcast that uses `/pl_c` as thumbnail:
<img height="200" alt="image" src="https://github.com/user-attachments/assets/b6e16631-169e-46ef-b57a-1d76307f32a4" />

Playlist that uses `/tvfilm_banner` as thumbnail:
<img height="200" alt="image" src="https://github.com/user-attachments/assets/44dfdcae-bae9-4e96-91a2-d6aa874d394d" />


Fixes https://github.com/iv-org/invidious/issues/5738
Can be merged after https://github.com/iv-org/invidious/pull/5736 gets merged.