### PR TITLE
fix: resolve bounty issue #2513 - format listen-mode audio quality labels

### DIFF
--- a/spec/invidious/helpers_spec.cr
+++ b/spec/invidious/helpers_spec.cr
@@ -53,4 +53,12 @@ Spectator.describe "Helper" do
       expect(sign_token("SECRET_KEY", token)).to eq(token["signature"])
     end
   end
+
+  describe "#format_audio_quality_label" do
+    it "formats audio bitrates as readable kilobit labels" do
+      expect(Helpers.format_audio_quality_label(128000)).to eq("128k")
+      expect(Helpers.format_audio_quality_label(50000)).to eq("50k")
+      expect(Helpers.format_audio_quality_label(64000)).to eq("64k")
+    end
+  end
 end

--- a/src/invidious/helpers/helpers.cr
+++ b/src/invidious/helpers/helpers.cr
@@ -40,6 +40,10 @@ module Helpers
     return description
   end
 
+  def format_audio_quality_label(bitrate : Int64) : String
+    "#{(bitrate / 1000).round.to_i}k"
+  end
+
   def cache_annotation(id, annotations)
     if !CONFIG.cache_annotations
       return

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,12 +28,13 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate = fmt["bitrate"].as_i
+                quality_label = Helpers.format_audio_quality_label(bitrate)
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= quality_label %>" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
## Summary
Fix for [Bounty $10] Difficult to understand quality selection in listen mode — Issue #2513

## Root cause
The player.ecr template was displaying raw bitrate integers (e.g. 128000) with a 'k' suffix appended directly, resulting in confusing labels like '128000k' instead of readable '128k'.

## Fix
- Added  helper in  that divides bitrate by 1000 and rounds to integer
- Updated  to use the new helper for audio stream quality labels  
- Added spec coverage for the new helper

## Testing
- Added spec coverage in `spec/invidious/helpers_spec.cr` for the `format_audio_quality_label` helper

Closes #2513