### PR TITLE
fix: fix author verification in channels

### DIFF
--- a/src/invidious/channels/about.cr
+++ b/src/invidious/channels/about.cr
@@ -83,9 +83,12 @@ def get_about_info(ucid, locale) : AboutChannel
       author = initdata["metadata"]["channelMetadataRenderer"]["title"].as_s
       author_url = initdata["metadata"]["channelMetadataRenderer"]["channelUrl"].as_s
       author_thumbnail = initdata["metadata"]["channelMetadataRenderer"]["avatar"]["thumbnails"][0]["url"].as_s
-      author_verified = (initdata.dig?("header", "pageHeaderRenderer", "content", "pageHeaderViewModel", "title", "dynamicTextViewModel", "text", "attachmentRuns", 0, "element", "type", "imageType", "image", "sources", 0, "clientResource", "imageName")
-        .try &.as_s) == "CHECK_CIRCLE_FILLED" || false
-
+      author_badge = initdata.dig?("header", "pageHeaderRenderer", "content", "pageHeaderViewModel", "title", "dynamicTextViewModel", "text", "attachmentRuns", 0, "element", "type", "imageType", "image", "sources", 0, "clientResource", "imageName")
+        .try &.as_s
+      # CHECK_CIRCLE_FILLED is used for normal channels and AUDIO_BADGE if used For
+      # music/artist channels
+      # TODO: Maybe separate verified author from verified artist?
+      author_verified = author_badge.try { |badge| badge == "CHECK_CIRCLE_FILLED" || badge == "AUDIO_BADGE" } || false
       ucid = initdata["metadata"]["channelMetadataRenderer"]["externalId"].as_s
 
       # Raises a KeyError on failure.

--- a/src/invidious/channels/about.cr
+++ b/src/invidious/channels/about.cr
@@ -83,11 +83,13 @@ def get_about_info(ucid, locale) : AboutChannel
       author = initdata["metadata"]["channelMetadataRenderer"]["title"].as_s
       author_url = initdata["metadata"]["channelMetadataRenderer"]["channelUrl"].as_s
       author_thumbnail = initdata["metadata"]["channelMetadataRenderer"]["avatar"]["thumbnails"][0]["url"].as_s
-      author_verified = has_verified_badge?(initdata.dig?("header", "c4TabbedHeaderRenderer", "badges"))
+      author_verified = (initdata.dig?("header", "pageHeaderRenderer", "content", "pageHeaderViewModel", "title", "dynamicTextViewModel", "text", "attachmentRuns", 0, "element", "type", "imageType", "image", "sources", 0, "clientResource", "imageName")
+        .try &.as_s) == "CHECK_CIRCLE_FILLED" || false
 
       ucid = initdata["metadata"]["channelMetadataRenderer"]["externalId"].as_s
 
       # Raises a KeyError on failure.
+      # TODO: Check if `c4TabbedHeaderRenderer` still exists on some channels.
       banners = initdata["header"]["c4TabbedHeaderRenderer"]?.try &.["banner"]?.try &.["thumbnails"]?
       banners ||= initdata.dig?("header", "pageHeaderRenderer", "content", "pageHeaderViewModel", "banner", "imageBannerViewModel", "image", "sources")
       banner = banners.try &.[-1]?.try &.["url"].as_s?


### PR DESCRIPTION
Fixes https://github.com/iv-org/invidious/issues/5730

Author verification badge is not longer located in `c4TabbedHeaderRenderer`. It may be deprecated.