### PR TITLE
fix: Do not append query params `quality=medium` to videos that are about to premiere

### DIFF
--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -129,17 +129,20 @@ module Invidious::Routes::Watch
     video_streams = video.video_streams
     audio_streams = video.audio_streams
 
-    # Older videos may not have audio sources available.
-    # We redirect here so they're not unplayable
-    if audio_streams.empty? && !video.live_now
-      if params.quality == "dash"
-        env.params.query.delete_all("quality")
-        env.params.query["quality"] = "medium"
-        return env.redirect "/watch?#{env.params.query}"
-      elsif params.listen
-        env.params.query.delete_all("listen")
-        env.params.query["listen"] = "0"
-        return env.redirect "/watch?#{env.params.query}"
+    # Videos that are a premiere do not have audio streams.
+    if !video.premiere_timestamp.nil?
+      # Older videos may not have audio sources available.
+      # We redirect here so they're not unplayable
+      if audio_streams.empty? && !video.live_now
+        if params.quality == "dash"
+          env.params.query.delete_all("quality")
+          env.params.query["quality"] = "medium"
+          return env.redirect "/watch?#{env.params.query}"
+        elsif params.listen
+          env.params.query.delete_all("listen")
+          env.params.query["listen"] = "0"
+          return env.redirect "/watch?#{env.params.query}"
+        end
       end
     end
 

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -129,20 +129,17 @@ module Invidious::Routes::Watch
     video_streams = video.video_streams
     audio_streams = video.audio_streams
 
-    # Videos that are a premiere do not have audio streams.
-    if !video.premiere_timestamp.nil?
-      # Older videos may not have audio sources available.
-      # We redirect here so they're not unplayable
-      if audio_streams.empty? && !video.live_now
-        if params.quality == "dash"
-          env.params.query.delete_all("quality")
-          env.params.query["quality"] = "medium"
-          return env.redirect "/watch?#{env.params.query}"
-        elsif params.listen
-          env.params.query.delete_all("listen")
-          env.params.query["listen"] = "0"
-          return env.redirect "/watch?#{env.params.query}"
-        end
+    # Older videos may not have audio sources available.
+    # We redirect here so they're not unplayable
+    if audio_streams.empty? && !video.live_now
+      if params.quality == "dash"
+        env.params.query.delete_all("quality")
+        env.params.query["quality"] = "medium"
+        return env.redirect "/watch?#{env.params.query}"
+      elsif params.listen
+        env.params.query.delete_all("listen")
+        env.params.query["listen"] = "0"
+        return env.redirect "/watch?#{env.params.query}"
       end
     end
 

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -129,17 +129,20 @@ module Invidious::Routes::Watch
     video_streams = video.video_streams
     audio_streams = video.audio_streams
 
-    # Older videos may not have audio sources available.
-    # We redirect here so they're not unplayable
-    if audio_streams.empty? && !video.live_now
-      if params.quality == "dash"
-        env.params.query.delete_all("quality")
-        env.params.query["quality"] = "medium"
-        return env.redirect "/watch?#{env.params.query}"
-      elsif params.listen
-        env.params.query.delete_all("listen")
-        env.params.query["listen"] = "0"
-        return env.redirect "/watch?#{env.params.query}"
+    # Videos that are a premiere do not have audio streams.
+    if video.premiere_timestamp.nil?
+      # Older videos may not have audio sources available.
+      # We redirect here so they're not unplayable
+      if audio_streams.empty? && !video.live_now
+        if params.quality == "dash"
+          env.params.query.delete_all("quality")
+          env.params.query["quality"] = "medium"
+          return env.redirect "/watch?#{env.params.query}"
+        elsif params.listen
+          env.params.query.delete_all("listen")
+          env.params.query["listen"] = "0"
+          return env.redirect "/watch?#{env.params.query}"
+        end
       end
     end
 

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -81,9 +81,10 @@ struct Video
   end
 
   def premiere_timestamp : Time?
-    info
-      .dig?("microformat", "playerMicroformatRenderer", "liveBroadcastDetails", "startTimestamp")
-      .try { |t| Time.parse_rfc3339(t.as_s) }
+    if self.video_type == VideoType::Scheduled
+      return info["published"]?
+        .try { |t| Time.parse_rfc3339(t.as_s) }
+    end
   end
 
   def related_videos

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -109,7 +109,7 @@ module Invidious::Videos::Parser
     params = self.parse_video_info(video_id, player_response)
     params["reason"] = JSON::Any.new(reason) if reason
 
-    {"captions", "playabilityStatus", "playerConfig", "storyboards", "microformat"}.each do |f|
+    {"captions", "playabilityStatus", "playerConfig", "storyboards"}.each do |f|
       params[f] = player_response[f] if player_response[f]?
     end
 

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -109,7 +109,7 @@ module Invidious::Videos::Parser
     params = self.parse_video_info(video_id, player_response)
     params["reason"] = JSON::Any.new(reason) if reason
 
-    {"captions", "playabilityStatus", "playerConfig", "storyboards"}.each do |f|
+    {"captions", "playabilityStatus", "playerConfig", "storyboards", "microformat"}.each do |f|
       params[f] = player_response[f] if player_response[f]?
     end
 


### PR DESCRIPTION
Video premieres do not have `audio_streams` and they aren't `video.live_now == true` either, therefore we skip the checks that are made for older videos (`if audio_streams.empty? && !video.live_now` closure) if the video is a premiere.

`Video#premiere_timestamp` returns the premiere timestamp based on:

https://github.com/iv-org/invidious/blob/1a5a71b086c92f16e9c1df74b834c80c7e41e42c/src/invidious/videos/parser.cr#L401-L408

`video_type` will be `Scheduled` if it's a premiere and it's published time it's the premiere timestamp.

~~This commit also adds the `microformat` field to the `info` instance variable of the `Video` struct, since it's needed for the function `Video#premiere_timestamp : Time?`. This is more like a quick fix than a proper fix because in `Invidious::Videos::Parser#parse_video_info`, `premiere_timestamp` is gathered from the `microformat` JSON Object but is used to set the `published` hash key for the `params` variable.~~. Replaced by a simpler logic (https://github.com/iv-org/invidious/pull/5755/commits/a6d4c488ef000888a532c49a605790ad91110ab0 and https://github.com/iv-org/invidious/pull/5755/commits/5f9b474ecb62a6ee01656716dd57cc609aef57fa)

The parsers and structs really need a rework :/

Fixes https://github.com/iv-org/invidious/issues/4484