### PR TITLE
Fix listen mode quality labels (bps → kbps)

### DIFF
--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -167,8 +167,10 @@ module Invidious::Routes::Watch
         url = audio_streams[0]["url"].as_s
 
         if params.quality.ends_with? "k"
+          target = params.quality.rchop("k").to_i
           audio_streams.each do |fmt|
-            if fmt["bitrate"].as_i == params.quality.rchop("k").to_i
+            bitrate = fmt["bitrate"].as_i
+            if bitrate == target || bitrate // 1000 == target
               url = fmt["url"].as_s
             end
           end

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,12 +28,12 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate_kbps = fmt["bitrate"].as_i // 1000
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate_kbps %>k" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
## Summary

Fixes #2513 — listen mode quality selector showed values like `128000k` because audio stream `bitrate` from YouTube is in **bps**, while labels were suffixed with `k` as if already kbps.

- **`player.ecr`**: display `bitrate // 1000` in source labels (e.g. `128k`).
- **`watch.cr`**: when matching `?quality=…k`, accept both raw bps and kbps values so selection still works.

## Verification

- User confirmed labels render correctly on another PC (listen mode, quality gear menu).
- Full local build not run here (Crystal/Docker unavailable in this environment).

## Test plan

- [x] Open a video in listen mode
- [x] Open quality selector — labels should show sensible kbps values (e.g. `128k`, not `128000k`)
- [x] Selecting a quality still plays the expected stream

Made with [Cursor](https://cursor.com)