### PR TITLE
Fix listen mode audio quality labels

### DIFF
--- a/spec/invidious/videos/formats_spec.cr
+++ b/spec/invidious/videos/formats_spec.cr
@@ -1,0 +1,25 @@
+require "json"
+require "spectator"
+require "../../../src/invidious/videos/formats"
+
+Spectator.describe Invidious::Videos::Formats do
+  describe ".audio_quality_label" do
+    it "uses the known audio bitrate for mapped itags" do
+      fmt = {
+        "itag"    => JSON::Any.new(140_i64),
+        "bitrate" => JSON::Any.new(128_619_i64),
+      }
+
+      expect(Invidious::Videos::Formats.audio_quality_label(fmt)).to eq("128 kbps")
+    end
+
+    it "falls back to a rounded bitrate for unknown itags" do
+      fmt = {
+        "itag"    => JSON::Any.new(123_456_i64),
+        "bitrate" => JSON::Any.new(70_499_i64),
+      }
+
+      expect(Invidious::Videos::Formats.audio_quality_label(fmt)).to eq("70 kbps")
+    end
+  end
+end

--- a/src/invidious/videos/formats.cr
+++ b/src/invidious/videos/formats.cr
@@ -3,6 +3,16 @@ module Invidious::Videos::Formats
     return FORMATS[itag.to_s]?
   end
 
+  def self.audio_quality_label(fmt : Hash(String, JSON::Any)) : String
+    if metadata = itag_to_metadata?(fmt["itag"])
+      if abr = metadata["abr"]?
+        return "#{abr} kbps"
+      end
+    end
+
+    "#{(fmt["bitrate"].as_i + 500) // 1000} kbps"
+  end
+
   # See https://github.com/rg3/youtube-dl/blob/master/youtube_dl/extractor/youtube.py#L380-#L476
   private FORMATS = {
     "5"  => {"ext" => "flv", "width" => 400, "height" => 240, "acodec" => "mp3", "abr" => 64, "vcodec" => "h263"},

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,12 +28,12 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                quality_label = Invidious::Videos::Formats.audio_quality_label(fmt)
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= quality_label %>" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
## Summary
- Normalize listen-mode audio quality labels so raw bitrates like `128619` no longer display as `128619k`.
- Prefer known YouTube itag audio bitrates when available, falling back to rounded kbps labels for unknown formats.
- Add focused coverage for mapped and fallback audio quality labels.

Fixes: #2513
I want to be awarded the bounty associated to the issue this PR is fixing.

## Tests
- `crystal spec spec/invidious/videos/formats_spec.cr`
- `crystal build src/invidious.cr -Dskip_videojs_download --no-codegen --error-trace`
