### PR TITLE
[RefreshChannelsJob] Reduce backoff if no errors occur

### DIFF
--- a/src/invidious/jobs/refresh_channels_job.cr
+++ b/src/invidious/jobs/refresh_channels_job.cr
@@ -36,6 +36,11 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
 
               LOGGER.trace("RefreshChannelsJob: #{id} fiber : Updating DB")
               Invidious::Database::Channels.update_author(id, channel.author)
+
+              if backoff > 2.minutes
+                backoff /= 2
+                LOGGER.info("RefreshChannelsJob: #{id} fiber : decreasing backoff to #{backoff}s")
+              end
             rescue ex
               LOGGER.error("RefreshChannelsJob: #{id} : #{ex.message}")
               if ex.message == "Deleted or invalid channel"

--- a/src/invidious/jobs/refresh_channels_job.cr
+++ b/src/invidious/jobs/refresh_channels_job.cr
@@ -39,7 +39,7 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
 
               if backoff > 2.minutes
                 backoff /= 2
-                LOGGER.info("RefreshChannelsJob: #{id} fiber : decreasing backoff to #{backoff}s")
+                LOGGER.debug("RefreshChannelsJob: #{id} fiber : decreasing backoff to #{backoff}s")
               end
             rescue ex
               LOGGER.error("RefreshChannelsJob: #{id} : #{ex.message}")


### PR DESCRIPTION
Currently there is no code in refresh_channels_job.cr to gradually reduce the backoff, causing it to increase forever even if errors occur sporadically:

<img width="846" height="186" alt="image" src="https://github.com/user-attachments/assets/631aec9d-0c01-4562-9aa2-3b9846bd5504" />

This PR halves the backoff whenever there are no errors fetching the channel info, until its initial value of 2 minutes.