### PR TITLE
Fix listen-mode audio quality labels

### DIFF
--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,12 +28,12 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate_kbps = fmt["bitrate"].as_i // 1000
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate_kbps %>k" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
## Summary
- convert listen-mode audio stream bitrates from bits/sec to kbps before rendering quality labels
- keeps labels like `128k` instead of showing raw values like `128000k`

Fixes #2513.

## Validation
- `git diff --check`

I could not run the Crystal spec/build suite locally because this machine does not have Crystal, Shards, or Docker installed.