### PR TITLE
Fix listen-mode audio quality labels

### DIFF
--- a/spec/invidious/helpers_spec.cr
+++ b/spec/invidious/helpers_spec.cr
@@ -53,4 +53,12 @@ Spectator.describe "Helper" do
       expect(sign_token("SECRET_KEY", token)).to eq(token["signature"])
     end
   end
+
+  describe "#audio_bitrate_label" do
+    it "formats bitrates as kilobit labels" do
+      expect(audio_bitrate_label(128000)).to eq("128k")
+      expect(audio_bitrate_label(50000)).to eq("50k")
+      expect(audio_bitrate_label(JSON::Any.new(160000_i64))).to eq("160k")
+    end
+  end
 end

--- a/src/invidious/frontend/watch_page.cr
+++ b/src/invidious/frontend/watch_page.cr
@@ -88,7 +88,7 @@ module Invidious::Frontend::WatchPage
         value = {"itag": option["itag"], "ext": mimetype.split("/")[1]}.to_json
 
         str << "\t\t\t<option value='" << value << "'>"
-        str << mimetype << " @ " << (option["bitrate"]?.try &.as_i./ 1000) << "k - audio only"
+        str << mimetype << " @ " << audio_bitrate_label(option["bitrate"]) << " - audio only"
         str << "</option>\n"
       end
 

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -202,6 +202,14 @@ def number_to_short_text(number)
   text
 end
 
+def audio_bitrate_label(bitrate : Int) : String
+  "#{bitrate // 1000}k"
+end
+
+def audio_bitrate_label(bitrate : JSON::Any) : String
+  audio_bitrate_label(bitrate.as_i)
+end
+
 def arg_array(array, start = 1)
   if array.size == 0
     args = "NULL"

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,12 +28,12 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate = audio_bitrate_label(fmt["bitrate"])
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
## Summary
- format listen-mode audio stream labels from raw bits-per-second values into readable kilobit labels
- reuse the same formatting for audio-only download options
- add helper coverage for bitrate label formatting

Fixes #2513

## Testing
- Not run locally: Crystal is not installed in this Windows environment.

## Bounty
This addresses the `bounty:10$` issue #2513.