### PR TITLE
Fix listen mode audio bitrate labels

### DIFF
--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -72,15 +72,16 @@ module Invidious::Routes::API::Manifest
               lang = audio_track["id"]?.try &.as_s.split('.')[0] || "und"
               is_default = audio_track.has_key?("audioIsDefault") ? audio_track["audioIsDefault"].as_bool : i == 0
               displayname = audio_track["displayName"]?.try &.as_s || "Unknown"
-              bitrate = fmt["bitrate"]
+              bitrate = fmt["bitrate"].as_i
+              bitrate_kbps = (bitrate / 1000).round.to_i
 
               # Different representations of the same audio should be groupped into one AdaptationSet.
               # However, most players don't support auto quality switching, so we have to trick them
               # into providing a quality selector.
               # See https://github.com/iv-org/invidious/issues/3074 for more details.
-              xml.element("AdaptationSet", id: i, mimeType: mime_type, startWithSAP: 1, subsegmentAlignment: true, label: "#{displayname} [#{bitrate}k]", lang: lang) do
+              xml.element("AdaptationSet", id: i, mimeType: mime_type, startWithSAP: 1, subsegmentAlignment: true, label: "#{displayname} [#{bitrate_kbps}k]", lang: lang) do
                 codecs = fmt["mimeType"].as_s.split("codecs=")[1].strip('"')
-                bandwidth = fmt["bitrate"].as_i
+                bandwidth = bitrate
                 itag = fmt["itag"].as_i
                 url = fmt["url"].as_s
 

--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -167,8 +167,11 @@ module Invidious::Routes::Watch
         url = audio_streams[0]["url"].as_s
 
         if params.quality.ends_with? "k"
+          bitrate = params.quality.rchop("k").to_i
+          bitrate *= 1000 if bitrate < 1000
+
           audio_streams.each do |fmt|
-            if fmt["bitrate"].as_i == params.quality.rchop("k").to_i
+            if fmt["bitrate"].as_i == bitrate
               url = fmt["url"].as_s
             end
           end

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,12 +28,13 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate = fmt["bitrate"].as_i
+                bitrate_kbps = (bitrate / 1000).round.to_i
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate_kbps %>k" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
## Summary
- show listen-mode audio stream labels in kbps instead of raw bits-per-second values like `128000k`
- keep raw listen-mode `quality=128k` selection compatible by converting kbps back to bps before matching stream bitrate
- use the same kbps display for DASH audio adaptation-set labels

Closes #2513.

## Validation
- `git diff --check`
- `docker run --rm --entrypoint /bin/sh -v "$PWD":/app -w /app 84codes/crystal:1.20.2-alpine -lc 'crystal --version && crystal tool format --check src/invidious/routes/api/manifest.cr src/invidious/routes/watch.cr'`
- `docker run --rm --entrypoint /bin/sh -v "$PWD":/app -w /app 84codes/crystal:1.20.2-alpine -lc 'apk add --no-cache sqlite-static yaml-static libxml2-dev xz-dev git >/dev/null && git config --global --add safe.directory /app && shards install && crystal build src/invidious.cr -Dskip_videojs_download --no-codegen --warnings all --error-on-warnings --stats --time --progress --error-trace'`
