### PR TITLE
Use “www.youtube.com” consistently

### DIFF
--- a/src/invidious/helpers/errors.cr
+++ b/src/invidious/helpers/errors.cr
@@ -201,7 +201,7 @@ def error_redirect_helper(env : HTTP::Server::Context)
           <a href="/redirect?referer=#{env.get("current_page")}">#{switch_instance}</a>
         </li>
         <li>
-          <a rel="noreferrer noopener" href="https://youtube.com#{env.request.resource}">#{go_to_youtube}</a>
+          <a rel="noreferrer noopener" href="https://www.youtube.com#{env.request.resource}">#{go_to_youtube}</a>
         </li>
       </ul>
     END_HTML

--- a/src/invidious/routes/channels.cr
+++ b/src/invidious/routes/channels.cr
@@ -351,7 +351,7 @@ module Invidious::Routes::Channels
     invidious_url_params.delete_all("user")
 
     begin
-      resolved_url = YoutubeAPI.resolve_url("https://youtube.com#{env.request.path}#{yt_url_params.size > 0 ? "?#{yt_url_params}" : ""}")
+      resolved_url = YoutubeAPI.resolve_url("https://www.youtube.com#{env.request.path}#{yt_url_params.size > 0 ? "?#{yt_url_params}" : ""}")
       ucid = resolved_url["endpoint"]["browseEndpoint"]["browseId"]
     rescue ex : InfoException | KeyError
       return error_template(404, I18n.translate(locale, "This channel does not exist."))

--- a/src/invidious/routes/errors.cr
+++ b/src/invidious/routes/errors.cr
@@ -8,7 +8,7 @@ module Invidious::Routes::ErrorRoutes
     if md = env.request.path.match(/^\/(?<id>([a-zA-Z0-9_-]{11})|(\w+))$/)
       item = md["id"]
 
-      # Check if item is branding URL e.g. https://youtube.com/gaming
+      # Check if item is branding URL e.g. https://www.youtube.com/gaming
       response = YT_POOL.client &.get("/#{item}")
 
       if response.status_code == 301

--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -480,7 +480,7 @@ module YoutubeAPI
   #
   # ```
   # # Valid channel "brand URL" gives the related UCID and browse ID
-  # channel_a = YoutubeAPI.resolve_url("https://youtube.com/c/google")
+  # channel_a = YoutubeAPI.resolve_url("https://www.youtube.com/c/google")
   # channel_a # => {
   #   "endpoint": {
   #     "browseEndpoint": {
@@ -492,7 +492,7 @@ module YoutubeAPI
   # }
   #
   # # Invalid URL returns throws an InfoException
-  # channel_b = YoutubeAPI.resolve_url("https://youtube.com/c/invalid")
+  # channel_b = YoutubeAPI.resolve_url("https://www.youtube.com/c/invalid")
   # ```
   #
   def resolve_url(url : String, client_config : ClientConfig | Nil = nil)


### PR DESCRIPTION
When using the “Go to YouTube” link on error pages, I sometimes get an “Access denied” error from YouTube. When using the canonical domain with the “www.” prefix, this does not seem to happen. Also, this saves an unnecessary redirect.