### PR TITLE
Fix audio quality bitrate labels

### DIFF
--- a/src/invidious/routes/watch.cr
+++ b/src/invidious/routes/watch.cr
@@ -167,8 +167,10 @@ module Invidious::Routes::Watch
         url = audio_streams[0]["url"].as_s
 
         if params.quality.ends_with? "k"
+          requested_bitrate = params.quality.rchop("k").to_i
           audio_streams.each do |fmt|
-            if fmt["bitrate"].as_i == params.quality.rchop("k").to_i
+            bitrate = fmt["bitrate"].as_i
+            if bitrate == requested_bitrate || bitrate // 1000 == requested_bitrate
               url = fmt["url"].as_s
             end
           end

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,7 +28,7 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate = fmt["bitrate"].as_i // 1000
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)


### PR DESCRIPTION
## Summary

- Render audio-only quality labels in listen mode using kbps instead of the raw bitrate value
- Keep `/watch?...&raw=1&listen=1&quality=...k` compatible with both raw bps-style values and kbps-style values

## Details

In listen mode, the player quality selector used `fmt["bitrate"]` directly and appended `k`, so a 128 kbps audio stream could be shown as `128000k`. The template now converts the bitrate to kbps before rendering the source label, producing labels like `128k`.

The raw audio redirect path now accepts either `128000k` or `128k` when matching an audio stream, so existing links remain compatible while the displayed value is easier to understand.

Fixes #2513

## Testing

- `git diff --check -- src\invidious\views\components\player.ecr src\invidious\routes\watch.cr`

I could not run the Crystal test suite in this environment because `crystal` and `shards` are not installed.
