### PR TITLE
Use progressive quality selector on iOS DASH

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -38,6 +38,17 @@ if (player_data.aspect_ratio) {
     options.aspectRatio = player_data.aspect_ratio;
 }
 
+function isAppleMobileDevice() {
+    return /iP(ad|hone|od)/.test(navigator.platform) ||
+        (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+}
+
+var shouldUseProgressiveQualitySelector = (
+    !video_data.params.listen &&
+    video_data.params.quality === 'dash' &&
+    isAppleMobileDevice()
+);
+
 var embed_url = new URL(location);
 embed_url.searchParams.delete('v');
 var short_url = location.origin + '/' + video_data.id + embed_url.search;
@@ -57,7 +68,7 @@ videojs.Vhs.xhr.beforeRequest = function(options) {
 var player = videojs('player', options);
 
 player.on('error', function () {
-    if (video_data.params.quality === 'dash') return;
+    if (video_data.params.quality === 'dash' && !shouldUseProgressiveQualitySelector) return;
 
     var localNotDisabled = (
         !player.currentSrc().includes('local=true') && !video_data.local_disabled
@@ -93,7 +104,7 @@ player.on('error', function () {
     }
 });
 
-if (video_data.params.quality === 'dash') {
+if (video_data.params.quality === 'dash' && !shouldUseProgressiveQualitySelector) {
     player.reloadSourceOnError({
         errorInterval: 10
     });
@@ -215,8 +226,12 @@ if (isMobile()) {
 
     var buttons = ['playToggle', 'volumePanel', 'captionsButton'];
 
-    if (!video_data.params.listen && video_data.params.quality === 'dash') buttons.push('audioTrackButton');
-    if (video_data.params.listen || video_data.params.quality !== 'dash') buttons.push('qualitySelector');
+    if (!video_data.params.listen && video_data.params.quality === 'dash' && !shouldUseProgressiveQualitySelector) {
+        buttons.push('audioTrackButton');
+    }
+    if (video_data.params.listen || video_data.params.quality !== 'dash' || shouldUseProgressiveQualitySelector) {
+        buttons.push('qualitySelector');
+    }
 
     // Create new control bar object for operation buttons
     const ControlBar = videojs.getComponent('controlBar');
@@ -243,7 +258,7 @@ if (isMobile()) {
         var share_element = document.getElementsByClassName('vjs-share-control')[0];
         operations_bar_element.append(share_element);
 
-        if (!video_data.params.listen && video_data.params.quality === 'dash') {
+        if (!video_data.params.listen && video_data.params.quality === 'dash' && !shouldUseProgressiveQualitySelector) {
             var http_source_selector = document.getElementsByClassName('vjs-http-source-selector vjs-menu-button')[0];
             operations_bar_element.append(http_source_selector);
         }
@@ -408,7 +423,7 @@ if (video_data.params.autoplay) {
     });
 }
 
-if (!video_data.params.listen && video_data.params.quality === 'dash') {
+if (!video_data.params.listen && video_data.params.quality === 'dash' && !shouldUseProgressiveQualitySelector) {
     player.httpSourceSelector();
 
     if (video_data.params.quality_dash !== 'auto') {
@@ -791,7 +806,7 @@ if (player.share) player.share(shareOptions);
 // show the preferred caption by default
 if (player_data.preferred_caption_found) {
     player.ready(function () {
-        if (!video_data.params.listen && video_data.params.quality === 'dash') {
+        if (!video_data.params.listen && video_data.params.quality === 'dash' && !shouldUseProgressiveQualitySelector) {
             // play.textTracks()[0] on DASH mode is showing some debug messages
             player.textTracks()[1].mode = 'showing';
         } else {

--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -44,7 +44,7 @@
                src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
             %>
-                <source src="<%= src_url %>" type='application/dash+xml' label="dash">
+                <source src="<%= src_url %>" type='application/dash+xml' label="dash" hidequalityoption="true">
             <% end %>
 
             <%

--- a/src/invidious/views/components/player_sources.ecr
+++ b/src/invidious/views/components/player_sources.ecr
@@ -20,10 +20,8 @@
     <script src="/js/videojs-youtube-annotations.min.js?v=<%= ASSET_COMMIT %>"></script>
 <% end %>
 
-<% if params.listen || params.quality != "dash" %>
-    <link rel="stylesheet" href="/css/quality-selector.css?v=<%= ASSET_COMMIT %>">
-    <script src="/js/silvermine-videojs-quality-selector.min.js?v=<%= ASSET_COMMIT %>"></script>
-<% end %>
+<link rel="stylesheet" href="/css/quality-selector.css?v=<%= ASSET_COMMIT %>">
+<script src="/js/silvermine-videojs-quality-selector.min.js?v=<%= ASSET_COMMIT %>"></script>
 
 <% if !params.listen && params.vr_mode %>
     <link rel="stylesheet" href="/videojs/videojs-vr/videojs-vr.css?v=<%= ASSET_COMMIT %>">


### PR DESCRIPTION
## Summary

- Use the progressive quality selector on Apple mobile devices when the user preference is DASH
- Keep the DASH source hidden from the progressive quality selector
- Keep the existing DASH/http-source-selector path for non-Apple mobile and desktop browsers

## Details

iOS Safari does not reliably support the DASH flow used by the player. When users have DASH quality enabled, Invidious still renders progressive fallback sources, but the UI initializes the DASH-specific source selector instead of the normal quality selector. On iOS this can leave users stuck on a low fallback source with no gear menu to change quality.

This change detects Apple mobile devices and, only for that case, uses the progressive quality selector instead of the DASH source selector. The DASH source is marked with `hidequalityoption="true"` so the progressive selector shows actual video qualities rather than a `dash` entry.

Fixes #2236

## Testing

- `Get-Content -Raw assets\js\player.js | node --check`
- `git diff --check -- assets\js\player.js src\invidious\views\components\player.ecr src\invidious\views\components\player_sources.ecr`

I could not run the Crystal test suite or validate on a real iOS Safari device in this environment.
