### PR TITLE
fix: fix private invidious playlists on rss feeds from being fetched without authentication

### DIFF
--- a/src/invidious/routes/feeds.cr
+++ b/src/invidious/routes/feeds.cr
@@ -283,6 +283,11 @@ module Invidious::Routes::Feeds
       if playlist = Invidious::Database::Playlists.select(id: plid)
         videos = get_playlist_videos(playlist, offset: 0)
 
+        user = env.get?("user").try &.as(User)
+        if !playlist || playlist.privacy.private? && playlist.author != user.try &.email
+          return error_atom(404, "Playlist does not exist.")
+        end
+
         return XML.build(indent: "  ", encoding: "UTF-8") do |xml|
           xml.element("feed", "xmlns:yt": "http://www.youtube.com/xml/schemas/2015",
             "xmlns:media": "http://search.yahoo.com/mrss/", xmlns: "http://www.w3.org/2005/Atom",


### PR DESCRIPTION
Fixes https://github.com/iv-org/invidious/issues/5775

When creating an Invidious playlist and setting it to private, now it returns `<error>Playlist does not exist.</error>` as it should.

```
$ curl http://127.0.0.1:30001/feed/playlist/IVPLWsJ2HJvfY0dGDIHv_3WgPuOvri3Wv7B
<error>Playlist does not exist.</error>
```