### PR TITLE
Add require_login and require_login_for_embeds config options

### DIFF
--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -206,12 +206,13 @@ before_all do |env|
     path = env.request.path
     allowed = {
       "/login", "/register", "/api/",
+      "/embed/",
       "/sb/", "/vi/", "/s_p/", "/yts/", "/ggpht/",
       "/api/manifest/", "/videoplayback", "/latest_version",
       "/download", "/companion/",
     }
     unless allowed.any? { |p| path.starts_with?(p) }
-      env.redirect "/login?return_path=#{URI.encode_www_form(path)}"
+      env.redirect "/login?referer=#{URI.encode_www_form(path)}"
       halt env, 302
     end
   end

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -206,12 +206,15 @@ before_all do |env|
     path = env.request.path
     allowed = {
       "/login", "/register", "/api/",
-      "/embed/",
       "/sb/", "/vi/", "/s_p/", "/yts/", "/ggpht/",
       "/api/manifest/", "/videoplayback", "/latest_version",
       "/download", "/companion/",
     }
-    unless allowed.any? { |p| path.starts_with?(p) }
+
+    is_allowed = allowed.any? { |p| path.starts_with?(p) }
+    is_allowed ||= path.starts_with?("/embed/") && !CONFIG.require_login_for_embeds
+
+    unless is_allowed
       env.redirect "/login?referer=#{URI.encode_www_form(path)}"
       halt env, 302
     end

--- a/src/invidious.cr
+++ b/src/invidious.cr
@@ -200,6 +200,21 @@ end
 
 before_all do |env|
   Invidious::Routes::BeforeAll.handle(env)
+
+  # Redirect unauthenticated users if require_login is enabled
+  if CONFIG.require_login && env.get?("user").nil?
+    path = env.request.path
+    allowed = {
+      "/login", "/register", "/api/",
+      "/sb/", "/vi/", "/s_p/", "/yts/", "/ggpht/",
+      "/api/manifest/", "/videoplayback", "/latest_version",
+      "/download", "/companion/",
+    }
+    unless allowed.any? { |p| path.starts_with?(p) }
+      env.redirect "/login?return_path=#{URI.encode_www_form(path)}"
+      halt env, 302
+    end
+  end
 end
 
 Invidious::Routing.register_all

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -129,6 +129,7 @@ class Config
   property captcha_enabled : Bool = true
   property login_enabled : Bool = true
   property require_login : Bool = false
+  property require_login_for_embeds : Bool = false
   property registration_enabled : Bool = true
   property statistics_enabled : Bool = false
   property admins : Array(String) = [] of String

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -128,6 +128,7 @@ class Config
   property popular_enabled : Bool = true
   property captcha_enabled : Bool = true
   property login_enabled : Bool = true
+  property require_login : Bool = false
   property registration_enabled : Bool = true
   property statistics_enabled : Bool = false
   property admins : Array(String) = [] of String


### PR DESCRIPTION
Related to https://github.com/iv-org/invidious/issues/446

## Summary
Adds two new boolean config options:

- `require_login` - when enabled, unauthenticated users are redirected to 
  `/login` when accessing any page on the instance
- `require_login_for_embeds` - when enabled alongside `require_login`, 
  also restricts `/embed/` routes (default: false, so embeds remain 
  accessible on external sites by default)

## Use case
This is useful for private instances where the owner wants to restrict access to approved users only e.g. a family server

## What's exempted from the redirect

Even with `require_login: true`, the following are always accessible without login to avoid breaking functionality:

- `/login`, `/register`
- `/api/` (API routes)
- `/embed/` (unless `require_login_for_embeds: true`)
- `/vi/`, `/sb/`, `/ggpht/`, `/yts/`, `/s_p/` (thumbnails/assets)
- `/videoplayback`, `/latest_version`, `/download`, `/companion/` 

## Configuration

In `config.yml`:

​```require_login: true
​```
​```require_login_for_embeds: true  # optional, defaults to false
​```

## Note
Due to third-party cookie restrictions in modern browsers, enabling `require_login_for_embeds` will effectively disable embedding on external sites even for authenticated users. Only useful if embeds are served on the same domain as the instance.