### PR TITLE
Clarify listen-mode audio quality labels

### DIFF
--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -28,12 +28,13 @@
                 src_url = invidious_companion.public_url.to_s + src_url +
                             "&check=#{invidious_companion_check_id}" if (invidious_companion)
 
-                bitrate = fmt["bitrate"]
+                bitrate = fmt["bitrate"].as_i
+                bitrate_label = "#{bitrate // 1000} kbps audio"
                 mimetype = HTML.escape(fmt["mimeType"].as_s)
 
                 selected = (i == best_m4a_stream_index)
             %>
-                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate %>k" selected="<%= selected %>">
+                <source src="<%= src_url %>" type='<%= mimetype %>' label="<%= bitrate_label %>" selected="<%= selected %>">
                 <% if !params.local && !CONFIG.disabled?("local") %>
                 <source src="<%= src_url %>&local=true" type='<%= mimetype %>' hidequalityoption="true">
                 <% end %>


### PR DESCRIPTION
## Summary

Fixes: #2513

I want to be awarded the bounty associated to the issue this PR is fixing.

This updates the listen-mode player quality menu so audio-only stream labels are shown as clear kbps labels instead of raw bitrate values with a trailing `k`.

## Changes

- Convert the audio stream bitrate from bits per second to kilobits per second for the visible quality label.
- Add `kbps audio` to make it clear that the entries are audio-only bitrate choices.
- Leave the stream URL, selected-stream logic, and local fallback source unchanged.

## Validation

- `git diff --check`
- `crystal build src/invidious.cr -Dskip_videojs_download --no-codegen --progress --stats --error-trace`
- Manual source review: listen-mode audio labels now render from `bitrate_label`, for example `129 kbps audio`, instead of `129000k`.

Note: validation was run in the project-compatible Linux Crystal/Shards container after installing Crystal 1.20.3 and Shards 0.20.0 locally. Windows-native `shards install` is blocked unless Windows Developer Mode or elevated symlink permissions are enabled.

## Bounty payout

BTC: `159VtfSLdWwbvfXVR29TAPmJ9TUHmEMvsY`