### PR TITLE
Fix videos being incorrectly labelled as isUpcoming = true

### DIFF
--- a/src/invidious/helpers/serialized_yt_data.cr
+++ b/src/invidious/helpers/serialized_yt_data.cr
@@ -148,7 +148,7 @@ struct SearchVideo
   end
 
   def upcoming?
-    premiere_timestamp ? true : false
+    premiere_timestamp.try { |t| t.to_unix > 0 } ? true : false
   end
 end
 


### PR DESCRIPTION
The tenary operator currently just checks if the field is not nil but the parser initialises the SearchVideo struct with `Time.new(0)` if the premiere timestamp is unavailable (e.g. in the lockup view model parser), so the `isUpcoming` field in the API responses was incorrectly being set to `true`.