### PR TITLE
chore: update openssl to 3.6.3 in OCI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-# https://github.com/openssl/openssl/releases/tag/openssl-3.6.2
-ARG OPENSSL_VERSION='3.6.2'
-ARG OPENSSL_SHA256='aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f'
+# https://github.com/openssl/openssl/releases/tag/openssl-3.6.3
+ARG OPENSSL_VERSION='3.6.3'
+ARG OPENSSL_SHA256='243a86649cf6f23eeb6a2ff2456e09e5d77dd9018a54d3d96b0c6bdd6ba6c7f1'
 
 FROM 84codes/crystal:1.20.3-alpine AS dependabot-crystal
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

Updates OpenSSL from 3.6.2 to 3.6.3 in the OCI