### PR TITLE
chore: improve invidious companion proxying

### DIFF
--- a/src/invidious/routes/companion.cr
+++ b/src/invidious/routes/companion.cr
@@ -1,20 +1,22 @@
 module Invidious::Routes::Companion
+  extend self
+
   # GET /companion
-  def self.get_companion(env)
-    url = self.make_url
-    self.proxy_companion(env, "GET", url)
+  def get_companion(env)
+    url = make_url(env)
+    proxy_companion(env, "GET", url)
   end
 
   # POST /companion
-  def self.post_companion(env)
-    url = self.make_url
-    self.proxy_companion(env, "POST", url)
+  def post_companion(env)
+    url = make_url(env)
+    proxy_companion(env, "POST", url)
   end
 
   # OPTIONS /companion
-  def self.options_companion(env)
-    url = self.make_url
-    self.proxy_companion(env, "OPTIONS", url)
+  def options_companion(env)
+    url = make_url(env)
+    proxy_companion(env, "OPTIONS", url)
   end
 
   private def make_url(env)
@@ -22,9 +24,10 @@ module Invidious::Routes::Companion
     if env.request.query
       url += "?#{env.request.query}"
     end
+    url
   end
 
-  private def self.proxy_companion(env, method, url)
+  private def proxy_companion(env, method, url)
     begin
       COMPANION_POOL.client do |wrapper|
         wrapper.client.exec(method, url, env.request.headers, (env.request.body if method == "POST")) do |resp|

--- a/src/invidious/routes/companion.cr
+++ b/src/invidious/routes/companion.cr
@@ -1,60 +1,43 @@
 module Invidious::Routes::Companion
   # GET /companion
   def self.get_companion(env)
-    url = env.request.path
-    if env.request.query
-      url += "?#{env.request.query}"
-    end
-
-    begin
-      COMPANION_POOL.client do |wrapper|
-        wrapper.client.get(url, env.request.headers) do |resp|
-          return self.proxy_companion(env, resp)
-        end
-      end
-    rescue ex
-    end
+    url = self.make_url
+    self.proxy_companion(env, "GET", url)
   end
 
   # POST /companion
   def self.post_companion(env)
-    url = env.request.path
-    if env.request.query
-      url += "?#{env.request.query}"
-    end
-
-    begin
-      COMPANION_POOL.client do |wrapper|
-        wrapper.client.post(url, env.request.headers, env.request.body) do |resp|
-          return self.proxy_companion(env, resp)
-        end
-      end
-    rescue ex
-    end
+    url = self.make_url
+    self.proxy_companion(env, "POST", url)
   end
 
+  # OPTIONS /companion
   def self.options_companion(env)
+    url = self.make_url
+    self.proxy_companion(env, "OPTIONS", url)
+  end
+
+  private def make_url(env)
     url = env.request.path
     if env.request.query
       url += "?#{env.request.query}"
     end
+  end
 
+  private def self.proxy_companion(env, method, url)
     begin
       COMPANION_POOL.client do |wrapper|
-        wrapper.client.options(url, env.request.headers) do |resp|
-          return self.proxy_companion(env, resp)
+        wrapper.client.exec(method, url, env.request.headers, (env.request.body if method == "POST")) do |resp|
+          env.response.status_code = resp.status_code
+          resp.headers.each do |key, value|
+            env.response.headers[key] = value
+          end
+          env.response.headers["Via"] = "1.1 Invidious"
+          return IO.copy resp.body_io, env.response
         end
       end
     rescue ex
+      return error_json(502, "Couldn't proxy request to Invidious Companion.")
     end
-  end
-
-  private def self.proxy_companion(env, response)
-    env.response.status_code = response.status_code
-    response.headers.each do |key, value|
-      env.response.headers[key] = value
-    end
-
-    return IO.copy response.body_io, env.response
   end
 end


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

Improves how the Invidious Companion built-in proxy is written to reduce duplicated code, but it also adds the `Via` response headers so the client connecting knows that the request is being proxied (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Via), is not really necessary, but still useful for people that may prefer to proxy Invidious companion manually in their reverse proxy (HAProxy, NGINX, Caddy).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change centralizes Companion request forwarding for GET, POST, and OPTIONS requests, forwards upstream responses, adds a proxy `Via` header, and returns JSON when proxying fails.

A streamed Companion failure can still produce a malformed error response: bytes already copied from the upstream body are retained, retried, and then followed by the JSON error payload. The proxy also drops pre-existing `Via` hops when adding Invidious.

### T-Rex validation blocked
Artifact upload was unavailable because the environment did not provide an artifact-upload tool. The partial-stream failure was executed successfully, but its harness and captured logs could not be attached as published evidence.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Do not merge until the Companion proxy avoids appending an error payload after downstream body output has begun.

The real Companion route was exercised with an upstream Via chain and demonstrably removed those hops. A focused HTTP harness also reproduced duplicated partial upstream output before the proxy error body, although the environment could not publish that harness's artifacts.

**Files Needing Attention:** src/invidious/routes/companion.cr needs response buffering or output-state-aware failure handling, plus preservation of existing Via header values.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a P2 finding proof and prepared accompanying via-chain validation artifacts to support the finding.
- T-Rex produced a P1 finding proof.
- Artifact publication was blocked by the environment because no artifact-upload tool was available, and the harness could not attach published evidence.
- The validation includes an exact code location and chain behavior: the code path is at src/invidious/routes/companion.cr:38, the candidate execution shows upstream-downstream loss, and the append-only step preserves the chain.

<a href="https://app.greptile.com/trex/runs/19165360/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Partial companion output is retained and duplicated before the rescue JSON error**

   - **Bug**
     - When the upstream response body emits bytes and then raises, the response body contains two partial upstream prefixes followed by the JSON 502 error. The tested response was `UPSTREAM-PARTIALUPSTREAM-PARTIAL{"error":"Couldn't proxy request to Invidious Companion."}`.
   - **Cause**
     - `src/invidious/routes/companion.cr:39` writes through `IO.copy` before the rescue at lines 42-43 returns JSON. `CompanionConnectionPool#client` retries the yielded operation after the first exception, repeating the partial write before the outer rescue executes.
   - **Fix**
     - Avoid retrying the proxy operation after downstream output has begun. Buffer and validate the upstream body before committing it, or detect started output and abort the downstream response instead of appending an error body.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Companion proxy overwrites the received Via chain**

   - **Bug**
     - When Companion returns a response carrying `Via: 1.0 upstream-gateway, 1.1 companion-edge`, the downstream response from the candidate contains only `Via: 1.1 Invidious`; the pre-existing hops are lost.
   - **Cause**
     - After copying all upstream headers, line 38 assigns `env.response.headers["Via"] = "1.1 Invidious"`, replacing the copied header value rather than appending Invidious as a new proxy hop.
   - **Fix**
     - Append `1.1 Invidious` to an existing `Via` value (with comma separation), while setting it directly only when no upstream `Via` header exists.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/iv-org/invidious/commit/1dceabf4f2edf60344d648721d8a24d89deb7b7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51303595)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->