### PR TITLE
feat: Adds support for custom channel handle urls with tab paths (ex: `{INSTANCE}/markrober/streams`)

### DIFF
--- a/src/invidious/routes/channels.cr
+++ b/src/invidious/routes/channels.cr
@@ -335,6 +335,18 @@ module Invidious::Routes::Channels
     "posts",
   }
 
+  def self.potential_brand_redirect(env)
+    # Check for known tab in url before trying to brand_redirect (avoids unneeded request to YouTube)
+
+    selected_tab = env.params.url["tab"]?
+
+    if KNOWN_TABS.includes? selected_tab
+      brand_redirect(env)
+    else
+      Invidious::Routes::Misc.home(env)
+    end
+  end
+
   # Redirects brand url channels to a normal /channel/:ucid route
   def self.brand_redirect(env)
     locale = env.get("preferences").as(Preferences).locale

--- a/src/invidious/routes/channels.cr
+++ b/src/invidious/routes/channels.cr
@@ -338,7 +338,7 @@ module Invidious::Routes::Channels
   def self.potential_brand_redirect(env)
     # Check for known tab in url before trying to brand_redirect (avoids unneeded request to YouTube)
 
-    selected_tab = env.params.url["tab"]?
+    selected_tab = env.params.url["tab"]?.try &.downcase
 
     if KNOWN_TABS.includes? selected_tab
       brand_redirect(env)
@@ -369,7 +369,7 @@ module Invidious::Routes::Channels
       return error_template(404, I18n.translate(locale, "This channel does not exist."))
     end
 
-    selected_tab = env.params.url["tab"]?
+    selected_tab = env.params.url["tab"]?.try &.downcase
 
     if KNOWN_TABS.includes? selected_tab
       url = "/channel/#{ucid}/#{selected_tab}"

--- a/src/invidious/routing.cr
+++ b/src/invidious/routing.cr
@@ -40,6 +40,8 @@ module Invidious::Routing
       if CONFIG.enable_user_notifications
         get "/modify_notifications", Routes::Notifications, :modify
       end
+
+      get "/:user/:tab", Routes::Channels, :potential_brand_redirect
     {% end %}
 
     self.register_image_routes


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

- [x] AI was not used to create this pull request

## Pull request description

closes https://github.com/iv-org/invidious/issues/5802

This PR adds support for the custom channel handle urls with tab paths (ex: `{INSTANCE}/markrober/streams`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of channel URLs with tab names.
  - Tab matching is now case-insensitive for more reliable navigation.
  - Unknown channel tabs are routed to a general fallback page instead of producing incorrect results.
  - Added support for automatically handling user tab routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Channel-handle URLs with recognized tab names now resolve case-insensitively, while unknown tab paths continue to return to the homepage. The earlier API-only controller-reference failure no longer reproduces: an API-only Crystal build completes successfully and the frontend-only route is excluded from that build.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The normal frontend and API-only builds compile successfully. Focused execution confirms mixed-case recognized tabs redirect through channel resolution, unknown tabs do not invoke channel resolution, and the generic route is excluded from API-only builds.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - Ran crystal builds on origin/master and the PR head with -Dapi\_only and related flags; both completed successfully, and a focused -Dapi\_only route-registration check confirmed that the /:user/:tab route is inside the API-only compile-time exclusion guard and not registered for API-only builds; API\_ONLY=1 make verify also completed successfully, though its logged command did not include -Dapi\_only, so the explicit Crystal build remains the authoritative API-only check; these results indicate the API-only build no longer references the excluded Routes::Channels controller.
- - Ran the channel-tab harness before PR and at PR head; both runs exited successfully, with before-side behavior showing VIDEOS\_home and after-change behavior showing VIDEOS\_redirect once, while not-a-tab continues to resolve to home in both revisions; the frontend route-registration harness also ran and confirmed the generic /:user/:tab route is declared in the normal frontend block, and normal frontend semantic compilation completed with two pre-existing deprecation warnings.
- - Executed exact command results: crystal build with -Dapi\_only exited 0 on both baseline and PR head, and API\_ONLY=1 make verify exited 0, though its logged command lacks -Dapi\_only, which is why the explicit build was used as the authoritative API-only check; the artifacts include the baseline and PR compile logs and the Makefile verification log to verify these outcomes.
- - Verified specific run outputs: bash trex-artifacts/run-channel-tab-behavior.sh and bash trex-artifacts/run-frontend-channel-route-registration.sh exited 0 with the described api\_only\_compile\_flag and route-declaration states, and the normal frontend Crystal verification build completed successfully (with two deprecation warnings noted).

<a href="https://app.greptile.com/trex/runs/18204394/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: check known\_tabs against downcased ..."](https://github.com/iv-org/invidious/commit/a4fd9aaafbfd538f43f4600ce8a6310103bb7925) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51303594)</sub>

<!-- /greptile_comment -->