### PR TITLE
fix(parser): parse published date and view count for collab videos

### DIFF
--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -661,13 +661,25 @@ private module Parsers
 
         metadata = item_contents.dig("metadata", "lockupMetadataViewModel")
         title = metadata.dig("title", "content").as_s
+        published = nil
+        view_count_text = nil
         # Contains the views of the video and the published time of the video.
-        metadata_parts = metadata.dig("metadata", "contentMetadataViewModel", "metadataRows", 0, "metadataParts").try &.as_a
+        if (metadata_rows = metadata.dig("metadata", "contentMetadataViewModel", "metadataRows").try &.as_a)
+          metadata_rows.each do |row|
+            metadata_parts = row.dig("metadataParts").try &.as_a
 
-        view_count_text = metadata_parts.try &.find { |item| item["icon"]?.nil? && item.dig?("text", "content").try &.as_s.includes?("views") }
-          .try &.dig("text", "content").as_s
-        published = metadata_parts.try &.find { |item| item["icon"]?.nil? && item.dig?("text", "content").try &.as_s.includes?("ago") }
-          .try { |item| decode_date(item.dig("text", "content").as_s) } || Time.local
+            if view_count_text.nil?
+              view_count_text = metadata_parts.try &.find { |item| item["icon"]?.nil? && item.dig?("text", "content").try &.as_s.includes?("views") }
+                .try &.dig("text", "content").as_s
+            end
+            if published.nil?
+              published = metadata_parts.try &.find { |item| item["icon"]?.nil? && item.dig?("text", "content").try &.as_s.includes?("ago") }
+                .try { |item| decode_date(item.dig("text", "content").as_s) }
+            end
+
+            break if !view_count_text.nil? && !published.nil?
+          end
+        end
 
         view_count = short_text_to_number(view_count_text || "0")
 
@@ -680,7 +692,7 @@ private module Parsers
           id:                 video_id,
           author:             author_fallback.name,
           ucid:               author_fallback.id,
-          published:          published,
+          published:          published || Time.local,
           views:              view_count,
           description_html:   "",
           length_seconds:     length_seconds || 0,


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

- [x] AI was not used to create this pull request


## Pull request description

This PR fixes parsing of view count and published metadata for lockupviews (that are collabs)

closes: #5740

## Testing
- go to Veritasium YT Channel (`{INSTANCE}/channel/UCHnyfMqiRRG1u-2MsSQLbXA`)
- look for video titled `Google Maps is unreasonably fast. Let me explain`
- make sure that video now shows published date and view count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lockup video details parsing to reliably display view counts and publication times regardless of metadata order.
  * Added a fallback timestamp when publication information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change correctly extracts a video’s view count and publication time when YouTube places them in separate lockup metadata rows. A focused parser check confirmed the updated behavior and retained the existing empty-metadata fallback.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains; the updated metadata traversal correctly handles split publication and view-count rows.

No blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a non-committed Crystal harness through the repository parser bootstrap and the public parse\_item path; the split-row payload produced zero views in the parent revision but 1,500,000 views and a decoded publication time when evaluated as a SearchVideo on this revision, and empty metadata rows retain a zero-view fallback.
- The executed source and both captured command outputs were uploaded through the Greptile artifact upload slots; the after-run completed with exit code 0 and recorded only a pre-existing Crystal deprecation warning.

<a href="https://app.greptile.com/trex/runs/18202744/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(parser): parse published date and vi..."](https://github.com/iv-org/invidious/commit/eb567904784ea9b60d017a2b0b7132cf986a23e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51303593)</sub>

<!-- /greptile_comment -->