### PR TITLE
Hotfix - Fix YouTube change

### DIFF
--- a/src/invidious/yt_backend/youtube_api.cr
+++ b/src/invidious/yt_backend/youtube_api.cr
@@ -50,7 +50,7 @@ module YoutubeAPI
     ClientType::Web => {
       name:       "WEB",
       name_proto: "1",
-      version:    "2.20250222.10.00",
+      version:    "2.20250223.10.00",
       screen:     "WATCH_FULL_SCREEN",
       os_name:    "Windows",
       os_version: WINDOWS_VERSION,
@@ -76,7 +76,7 @@ module YoutubeAPI
     ClientType::WebScreenEmbed => {
       name:       "WEB",
       name_proto: "1",
-      version:    "2.20250222.10.00",
+      version:    "2.20250223.10.00",
       screen:     "EMBED",
       os_name:    "Windows",
       os_version: WINDOWS_VERSION,


### PR DESCRIPTION
# Credit to https://git.miningtcup.me/MiningTcup
Bump  ClientType::Web and ClientType::WebScreenEmbed up from `2.20250222.10.00` to `2.20250223.10.00`

From [this commit](https://git.miningtcup.me/MiningTcup/invidious/commit/0eae3747e935663e3b581da4864fa4e796de51c9) by [MiningTcup](https://git.miningtcup.me/MiningTcup)
## Checklist

- [X] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

- [X] AI was not used to create this pull request