### PR TITLE
Link hashtags in video titles

### DIFF
--- a/spec/invidious/helpers_spec.cr
+++ b/spec/invidious/helpers_spec.cr
@@ -3,6 +3,16 @@ require "../spec_helper"
 CONFIG = Config.from_yaml(File.open("config/config.example.yml"))
 
 Spectator.describe "Helper" do
+  describe "#parse_video_title" do
+    it "links hashtags in video titles" do
+      expect(parse_video_title("Video title #music")).to eq(%(Video title <a href="/hashtag/music">#music</a>))
+    end
+
+    it "escapes video titles before linking hashtags" do
+      expect(parse_video_title(%(<b>#music</b>))).to eq(%(&lt;b&gt;<a href="/hashtag/music">#music</a>&lt;/b&gt;))
+    end
+  end
+
   describe "#produce_channel_search_continuation" do
     it "correctly produces token for searching a specific channel" do
       expect(produce_channel_search_continuation("UCXuqSBlHAE6Xw-yeJA0Tunw", "", 100)).to eq("4qmFsgJqEhhVQ1h1cVNCbEhBRTZYdy15ZUpBMFR1bncaIEVnWnpaV0Z5WTJnd0FUZ0JZQUY2QkVkS2IxaTRBUUE9WgCaAilicm93c2UtZmVlZFVDWHVxU0JsSEFFNlh3LXllSkEwVHVud3NlYXJjaA%3D%3D")

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -20,6 +20,14 @@ def elapsed_text(elapsed)
   "#{(millis * 1000).round(2)}µs"
 end
 
+def parse_video_title(title : String) : String
+  HTML.escape(title).gsub(/(^|[[:space:]])#([A-Za-z0-9_]+)/) do |match|
+    prefix = match.starts_with?("#") ? "" : match[0].to_s
+    hashtag = match[prefix.size + 1..]
+    "#{prefix}<a href=\"/hashtag/#{URI.encode_path(hashtag)}\">##{hashtag}</a>"
+  end
+end
+
 def decode_length_seconds(string)
   length_seconds = string.gsub(/[^0-9:]/, "")
   return 0_i32 if length_seconds.empty?

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -1,5 +1,6 @@
 <% ucid = video.ucid %>
 <% title = HTML.escape(video.title) %>
+<% title_html = parse_video_title(video.title) %>
 <% author = HTML.escape(video.author) %>
 
 
@@ -77,7 +78,7 @@ we're going to need to do it here in order to allow for translations.
 
 <div class="h-box">
     <h1>
-        <%= title %>
+        <%= title_html %>
         <% if params.listen %>
             <a title="<%=I18n.translate(locale, "Video mode")%>" id="link-iv-listen" data-base-url="/watch?<%= env.params.query %>&listen=0" href="/watch?<%= env.params.query %>&listen=0">
                 <i class="icon ion-ios-videocam"></i>


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**
GPT-5 via OpenAI Codex.

**Tool(s) used:**
OpenAI Codex CLI/API coding environment, local git, GitHub API.

**How was AI used?**
AI assisted with repository navigation, patch drafting, and preparing this pull request text. I manually inspected the existing hashtag routes/parsers, PR #3137 context, issue #442, and the final diff.

---

## Pull request description

Fixes: #442.

I want to be awarded the bounty associated to the issue this PR is fixing.

Video titles were rendered with `HTML.escape(video.title)`, so hashtags in the visible watch-page title were plain text even though Invidious already has `/hashtag/:hashtag` routes and hashtag result parsing.

This adds `parse_video_title` to escape the title first, then link simple hashtags in the visible `<h1>` title to `/hashtag/:hashtag`. Meta tags and the document `<title>` continue to use the plain escaped title.

Validation:

- `git diff --check`
- Added helper specs for hashtag linking and HTML escaping.

I could not run Crystal specs locally because `crystal` is not installed in this environment.

Bounty payout: issue #442 mentions a 20 USD BTC bounty, and #1898 says Monero bounties can also be awarded as Monero. I can receive Monero at: `4DSQMNzzq46N1z2pZWAVdeA6JvUL9TCB2bnBiA3ZzoqEdYJnMydt5akCa3vtmapeDsbVKGPFdNkzqTcJS8M8oyK7WGjNk99k1B6CoKjvH5`.
