### PR TITLE
Parse lockup related video authors

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -55,6 +55,68 @@ module Invidious::Videos::Parser
     }
   end
 
+  def parse_related_lockup_video(related : JSON::Any) : Hash(String, JSON::Any)?
+    return nil if related["contentType"]?.try &.as_s != "LOCKUP_CONTENT_TYPE_VIDEO"
+    return nil if !related["contentId"]?
+
+    metadata = related.dig("metadata", "lockupMetadataViewModel")
+    thumbnail_view_model = related.dig?("contentImage", "thumbnailViewModel")
+
+    title = metadata.dig?("title", "content").try &.as_s || ""
+    length = thumbnail_view_model.try &.dig?("overlays", 0, "thumbnailBottomOverlayViewModel", "badges", 0, "thumbnailBadgeViewModel", "text").try &.as_s
+    length_seconds = decode_length_seconds(length) if length
+
+    metadata_rows = metadata.dig?("metadata", "contentMetadataViewModel", "metadataRows").try &.as_a
+    author_text = metadata_rows.try &.[0]?.try &.dig?("metadataParts", 0, "text", "content").try &.as_s || ""
+    metadata_parts = metadata_rows.try &.[1]?.try &.dig?("metadataParts").try &.as_a
+
+    short_view_count = metadata_parts.try &.find { |item| item.dig?("text", "content").try &.as_s.includes?("views") }
+      .try &.dig("text", "content").as_s
+    published = metadata_parts.try &.find { |item| item.dig?("text", "content").try &.as_s.includes?("ago") }
+      .try { |item| decode_date(item.dig("text", "content").as_s).to_rfc3339.to_s }
+
+    author_items = [] of JSON::Any
+
+    if author_info = metadata.dig?("image", "decoratedAvatarViewModel")
+      author = author_text
+      ucid = author_info.dig?("rendererContext", "commandContext", "onTap", "innertubeCommand", "browseEndpoint", "browseId").try &.as_s || ""
+      if !author.empty?
+        author_items << JSON::Any.new({
+          "author" => JSON::Any.new(author),
+          "ucid"   => JSON::Any.new(ucid),
+        })
+      end
+    elsif list_items = metadata.dig?("image", "avatarStackViewModel", "rendererContext", "commandContext", "onTap", "innertubeCommand", "showDialogCommand", "panelLoadingStrategy", "inlineContent", "dialogViewModel", "customContent", "listViewModel", "listItems").try &.as_a
+      list_items.each do |item|
+        list_item = item["listItemViewModel"]?
+        author = list_item.try &.dig?("title", "content").try &.as_s || ""
+        ucid = list_item.try &.dig?("rendererContext", "commandContext", "onTap", "innertubeCommand", "browseEndpoint", "browseId").try &.as_s || ""
+        next if author.empty?
+
+        author_items << JSON::Any.new({
+          "author" => JSON::Any.new(author),
+          "ucid"   => JSON::Any.new(ucid),
+        })
+      end
+    end
+
+    first_author = author_items[0]?.try &.["author"].as_s
+    first_ucid = author_items[0]?.try &.["ucid"].as_s
+    author = author_text.empty? ? (first_author || "") : author_text
+
+    return {
+      "id"               => related["contentId"],
+      "title"            => JSON::Any.new(title),
+      "author"           => JSON::Any.new(author),
+      "ucid"             => JSON::Any.new(first_ucid || ""),
+      "length_seconds"   => JSON::Any.new((length_seconds || 0).to_s),
+      "short_view_count" => JSON::Any.new(short_view_count || "0"),
+      "author_verified"  => JSON::Any.new("false"),
+      "published"        => JSON::Any.new(published || ""),
+      "author_items"     => JSON::Any.new(author_items),
+    }
+  end
+
   def extract_video_info(video_id : String)
     # Fetch data from the player endpoint
     player_response = YoutubeAPI.player(video_id: video_id)
@@ -246,6 +308,9 @@ module Invidious::Videos::Parser
     secondary_results.try &.as_a.each do |element|
       if item = element["compactVideoRenderer"]?
         related_video = self.parse_related_video(item)
+        related << JSON::Any.new(related_video) if related_video
+      elsif item = element["lockupViewModel"]?
+        related_video = self.parse_related_lockup_video(item)
         related << JSON::Any.new(related_video) if related_video
       end
     end

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -346,7 +346,18 @@ we're going to need to do it here in order to allow for translations.
 
                             <h5 class="pure-g">
                                 <div class="pure-u-14-24">
-                                    <% if !rv["ucid"].empty? %>
+                                    <% if !rv["author_items"]?.nil? && !rv["author_items"].as_a.empty? %>
+                                        <b style="width:100%">
+                                            <% rv["author_items"].as_a.each_with_index do |author_item, index| %>
+                                                <% if index > 0 %> and <% end %>
+                                                <% if !author_item["ucid"].empty? %>
+                                                    <a href="/channel/<%= author_item["ucid"] %>"><%= HTML.escape(author_item["author"].as_s) %></a>
+                                                <% else %>
+                                                    <%= HTML.escape(author_item["author"].as_s) %>
+                                                <% end %>
+                                            <% end %>
+                                        </b>
+                                    <% elsif !rv["ucid"].empty? %>
                                         <b style="width:100%"><a href="/channel/<%= rv["ucid"] %>"><%= rv["author"]? %><% if rv["author_verified"]? == "true" %>&nbsp;<i class="icon ion ion-md-checkmark-circle"></i><% end %></a></b>
                                     <% else %>
                                         <b style="width:100%"><%= rv["author"]? %><% if rv["author_verified"]? == "true" %>&nbsp;<i class="icon ion ion-md-checkmark-circle"></i><% end %></b>


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**
GPT-5 via OpenAI Codex.

**Tool(s) used:**
OpenAI Codex CLI/API coding environment, local git, GitHub API.

**How was AI used?**
AI assisted with repository navigation, patch drafting, and preparing this pull request text. I manually inspected issue #5722, the current related-video parser and watch template, the existing `lockupViewModel` parser, and a live Innertube `/next` response for `IZZVijQ0gkA`.

---

## Pull request description

Fixes: #5722.

I want to be awarded the bounty associated to the issue this PR is fixing.

YouTube now returns watch-page related videos as `lockupViewModel` items. The watch related-video parser only handled `compactVideoRenderer`, so author/channel data for these newer related items was not extracted for rendering.

This adds a related-video lockup parser that extracts:

- video id, title, length, view count, and published time
- single-channel author browse ids from `decoratedAvatarViewModel`
- collaborator channel browse ids from the `avatarStackViewModel` collaborator dialog

The watch template now renders collaborator author links individually when `author_items` is present, while preserving the existing single-author fallback for older related-video entries.

Validation:

- `git diff --check`
- Manually fetched and inspected the live Innertube `/next` response for `IZZVijQ0gkA`; related results are `lockupViewModel` entries, and collaboration channel ids are available under the avatar-stack dialog list items.

I could not run Crystal specs locally because `crystal` is not installed in this environment.

Bounty payout: issue #5722 mentions a 20 USD BTC bounty, and #1898 says Monero bounties can also be awarded as Monero. I can receive Monero at: `4DSQMNzzq46N1z2pZWAVdeA6JvUL9TCB2bnBiA3ZzoqEdYJnMydt5akCa3vtmapeDsbVKGPFdNkzqTcJS8M8oyK7WGjNk99k1B6CoKjvH5`.
