### PR TITLE
Fix lockup video metadata row parsing for collaboration videos

### DIFF
--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -661,12 +661,26 @@ private module Parsers
 
         metadata = item_contents.dig("metadata", "lockupMetadataViewModel")
         title = metadata.dig("title", "content").as_s
-        # Contains the views of the video and the published time of the video.
-        metadata_parts = metadata.dig("metadata", "contentMetadataViewModel", "metadataRows", 0, "metadataParts").try &.as_a
+        # Contains the author line and the views/published time. Collaboration
+        # videos can put those values in separate rows, so inspect all rows.
+        metadata_parts = [] of JSON::Any
+        if metadata_rows = metadata.dig?("metadata", "contentMetadataViewModel", "metadataRows").try &.as_a
+          metadata_rows.each do |row|
+            if parts = row["metadataParts"]?
+              metadata_parts.concat(parts.as_a)
+            end
+          end
+        end
 
-        view_count_text = metadata_parts.try &.find { |item| item["icon"]?.nil? && item.dig?("text", "content").try &.as_s.includes?("views") }
+        view_count_text = metadata_parts.find { |item|
+          item["icon"]?.nil? &&
+            item.dig?("text", "content").try &.as_s.includes?("views")
+        }
           .try &.dig("text", "content").as_s
-        published = metadata_parts.try &.find { |item| item["icon"]?.nil? && item.dig?("text", "content").try &.as_s.includes?("ago") }
+        published = metadata_parts.find { |item|
+          item["icon"]?.nil? &&
+            item.dig?("text", "content").try &.as_s.includes?("ago")
+        }
           .try { |item| decode_date(item.dig("text", "content").as_s) } || Time.local
 
         view_count = short_text_to_number(view_count_text || "0")


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**
OpenAI GPT-5 via Codex desktop app.

**Tool(s) used:**
OpenAI Codex desktop app.

**How was AI used?**
AI assisted with triaging the issue, locating the relevant parser code, drafting the small code change, and preparing this PR description. I reviewed the diff and checked sampled YouTube metadata before submitting.

---

## Pull request description

Fixes: #5740

I want to be awarded the bounty associated to the issue this PR is fixing.

YouTube can emit channel-page `LOCKUP_CONTENT_TYPE_VIDEO` metadata across multiple `metadataRows`. For collaboration videos, the first row can contain the collaborator/author line, while the views and published time are emitted in a later row. The previous parser only inspected `metadataRows[0]`, so it could miss `viewCount` and `published` for those videos.

### What changed

- Collect metadata parts from all `metadataRows` for `LOCKUP_CONTENT_TYPE_VIDEO`
- Keep the existing views/published extraction logic over the flattened parts
- Preserve the current fallback behavior when values are absent

### Verification

- Checked the issue example channel data from `https://www.youtube.com/channel/UCHnyfMqiRRG1u-2MsSQLbXA/videos`
- Confirmed a collaboration video can return one metadata row for collaborators, followed by another row containing values such as `7.7M views` and `1 month ago`
- Ran `git diff --check`

I could not run `crystal spec` locally because Crystal is not installed in this environment.