### PR TITLE
Parse related lockup video authors

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -55,6 +55,107 @@ module Invidious::Videos::Parser
     }
   end
 
+  def parse_related_lockup_video(related : JSON::Any) : Hash(String, JSON::Any)?
+    return nil if related["contentType"]?.try &.as_s != "LOCKUP_CONTENT_TYPE_VIDEO"
+    return nil if !related["contentId"]?
+
+    metadata = related.dig("metadata", "lockupMetadataViewModel")
+    thumbnail_view_model = related.dig?("contentImage", "thumbnailViewModel")
+    video_id = related["contentId"]
+    title = metadata.dig?("title", "content").try &.as_s || ""
+
+    length = thumbnail_view_model.try &.dig?(
+      "overlays", 0, "thumbnailBottomOverlayViewModel",
+      "badges", 0, "thumbnailBadgeViewModel", "text"
+    ).try &.as_s
+    length_seconds = decode_length_seconds(length) if length
+
+    metadata_parts = [] of JSON::Any
+    metadata_rows = metadata.dig?("metadata", "contentMetadataViewModel", "metadataRows")
+      .try &.as_a
+    if metadata_rows
+      metadata_rows.each do |row|
+        if parts = row["metadataParts"]?
+          metadata_parts.concat(parts.as_a)
+        end
+      end
+    end
+
+    author = metadata_parts.find { |item|
+      if text = item.dig?("text", "content").try &.as_s
+        !text.includes?("views") && !text.includes?("ago")
+      end
+    }.try &.dig("text", "content").as_s || ""
+
+    short_view_count = metadata_parts.find { |item|
+      item.dig?("text", "content").try &.as_s.includes?("views")
+    }
+      .try &.dig("text", "content").as_s
+
+    published = metadata_parts.find { |item|
+      item.dig?("text", "content").try &.as_s.includes?("ago")
+    }
+      .try { |item| decode_date(item.dig("text", "content").as_s).to_rfc3339.to_s }
+
+    author_items = [] of JSON::Any
+
+    if list_items = metadata
+         .dig?(
+           "image", "avatarStackViewModel", "rendererContext", "commandContext",
+           "onTap", "innertubeCommand", "showDialogCommand", "panelLoadingStrategy",
+           "inlineContent", "dialogViewModel", "customContent", "listViewModel", "listItems"
+         )
+         .try &.as_a
+      list_items.each do |list_item|
+        view = list_item["listItemViewModel"]?
+        next if !view
+
+        item_author = view.dig?("title", "content").try &.as_s || ""
+        item_ucid = view.dig?(
+          "rendererContext", "commandContext", "onTap",
+          "innertubeCommand", "browseEndpoint", "browseId"
+        ).try &.as_s || ""
+
+        next if item_author.empty?
+
+        author_items << JSON::Any.new({
+          "author" => JSON::Any.new(item_author),
+          "ucid"   => JSON::Any.new(item_ucid),
+        })
+      end
+    elsif author_info = metadata.dig?("image", "decoratedAvatarViewModel")
+      ucid = author_info.dig?(
+        "rendererContext", "commandContext", "onTap",
+        "innertubeCommand", "browseEndpoint", "browseId"
+      ).try &.as_s || ""
+
+      author_items << JSON::Any.new({
+        "author" => JSON::Any.new(author),
+        "ucid"   => JSON::Any.new(ucid),
+      }) if !author.empty?
+    end
+
+    ucid = ""
+    if first_author = author_items[0]?
+      ucid = first_author["ucid"].as_s
+    end
+
+    related_video = {
+      "id"               => video_id,
+      "title"            => JSON::Any.new(title),
+      "author"           => JSON::Any.new(author),
+      "ucid"             => JSON::Any.new(ucid),
+      "length_seconds"   => JSON::Any.new((length_seconds || 0).to_s),
+      "short_view_count" => JSON::Any.new(short_view_count || "0"),
+      "author_verified"  => JSON::Any.new("false"),
+      "published"        => JSON::Any.new(published || ""),
+    }
+
+    related_video["author_items"] = JSON::Any.new(author_items) if !author_items.empty?
+
+    return related_video
+  end
+
   def extract_video_info(video_id : String)
     # Fetch data from the player endpoint
     player_response = YoutubeAPI.player(video_id: video_id)
@@ -246,6 +347,9 @@ module Invidious::Videos::Parser
     secondary_results.try &.as_a.each do |element|
       if item = element["compactVideoRenderer"]?
         related_video = self.parse_related_video(item)
+        related << JSON::Any.new(related_video) if related_video
+      elsif item = element["lockupViewModel"]?
+        related_video = self.parse_related_lockup_video(item)
         related << JSON::Any.new(related_video) if related_video
       end
     end

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -346,7 +346,21 @@ we're going to need to do it here in order to allow for translations.
 
                             <h5 class="pure-g">
                                 <div class="pure-u-14-24">
-                                    <% if !rv["ucid"].empty? %>
+                                    <% if author_items = rv["author_items"]? %>
+                                        <b style="width:100%">
+                                            <% author_items.as_a.each_with_index do |author_item, index| %>
+                                                <% author_ucid = author_item["ucid"].as_s %>
+                                                <% if index > 0 %> and <% end %>
+                                                <% if !author_ucid.empty? %>
+                                                    <a href="/channel/<%= author_ucid %>">
+                                                        <%= HTML.escape(author_item["author"].as_s) %>
+                                                    </a>
+                                                <% else %>
+                                                    <%= HTML.escape(author_item["author"].as_s) %>
+                                                <% end %>
+                                            <% end %>
+                                        </b>
+                                    <% elsif !rv["ucid"].empty? %>
                                         <b style="width:100%"><a href="/channel/<%= rv["ucid"] %>"><%= rv["author"]? %><% if rv["author_verified"]? == "true" %>&nbsp;<i class="icon ion ion-md-checkmark-circle"></i><% end %></a></b>
                                     <% else %>
                                         <b style="width:100%"><%= rv["author"]? %><% if rv["author_verified"]? == "true" %>&nbsp;<i class="icon ion ion-md-checkmark-circle"></i><% end %></b>


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**
OpenAI GPT-5 via Codex desktop app.

**Tool(s) used:**
OpenAI Codex desktop app, local git, GitHub API.

**How was AI used?**
AI assisted with triaging the issue, inspecting the current parser/template code, sampling the live Innertube `/next` response for `IZZVijQ0gkA`, drafting the code change, and preparing this PR description. I reviewed the diff and the sampled metadata before submitting.

---

## Pull request description

Fixes: #5722

I want to be awarded the bounty associated to the issue this PR is fixing.

YouTube now returns watch-page related videos as `lockupViewModel` items. For collaboration videos, the channel IDs for each collaborator are available through the `avatarStackViewModel` collaborators dialog instead of the old `compactVideoRenderer` byline structure. The old related-video parser skipped those lockup items, leaving collaborator names without channel links.

### What changed

- Parse `LOCKUP_CONTENT_TYPE_VIDEO` related items from `lockupViewModel`
- Extract normal single-channel authors from `decoratedAvatarViewModel`
- Extract collaboration authors and channel IDs from the `avatarStackViewModel` collaborators dialog
- Render multiple related-video authors as individual channel links when available
- Preserve the existing single-author rendering fallback for older related-video data

### Verification

- Sampled the live Innertube `/next` response for `IZZVijQ0gkA`
- Confirmed related recommendations are returned as `lockupViewModel` items
- Confirmed collaboration examples include dialog list items with author names and `browseEndpoint.browseId` channel IDs
- Ran `git diff --check`

I could not run `crystal spec` locally because Crystal is not installed in this environment.