### PR TITLE
Implement fallback for empty author_id

### DIFF
--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -84,6 +84,15 @@ private module Parsers
         author_id = author_fallback.id
       end
 
+      # When ucid is still empty (e.g. collaboration videos with a composite
+      # channel name and no navigation endpoint), extract the first creator's
+      # channel ID from the channelThumbnailSupportedRenderers navigationEndpoint.
+      if author_id.empty?
+        if channel_id = item_contents.dig?("channelThumbnailSupportedRenderers", "channelThumbnailWithLinkRenderer", "navigationEndpoint", "browseEndpoint", "browseId").try &.as_s
+          author_id = channel_id
+        end
+      end
+
       author_thumbnail = item_contents.dig?("channelThumbnailSupportedRenderers", "channelThumbnailWithLinkRenderer", "thumbnail", "thumbnails", 0, "url").try &.as_s
 
       author_verified = has_verified_badge?(item_contents["ownerBadges"]?)


### PR DESCRIPTION
Add logic to extract channel ID for collaboration videos with empty author ID.

## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
DeepSeek V4 Flash

**Tool(s) used:**
OpenCode

**How was AI used?**
AI in IDE was used to read the invidious codebase, reason about problem specified by human, propose fixes and validate them. A few rounds of this feedback cycle was needed to get solution. Validation of the changes was done by human before submitting PR.

PR description was also made by AI but a human (me!) proof read it for correctness.

To verify proposed PR fixes issue #5722, pull changes and query for channels that regularly feature videos with collaborations:

http://localhost:3000/search?q=diary+ceo
http://localhost:3000/search?q=piers+morgan

Fix: Collaboration videos have the correct link to the first creator's channel. 

---

## Pull request description

**Problem**
Invidious search results render `collaboration` videos (e.g. "Piers Morgan Uncensored and Zeteo") with their channel name as plain text - no hyperlink.
This happens because YouTube's API, for collaboration videos, sends the `ownerText` as a single run containing the full composite name with no navigable `browseEndpoint`:
```
"ownerText": {
  "runs": [{"text": "Piers Morgan Uncensored and Zeteo"}]
}
```

The existing extraction code in `VideoRendererParser (extractors.cr:76-85)` takes `runs[0]`, reads its text as author, then calls `HelperExtractors.get_browse_id` which looks for `navigationEndpoint.browseEndpoint.browseId`. Since no `navigationEndpoint` exists, it returns `""`. The `ucid` field on `SearchVideo` is left empty, and the `template (item.ecr:184)` renders `<p>` instead of `<a>`.

**Solution**
When `author_id` is still empty after the primary extraction, extract the `first` creator's channel ID from the `channelThumbnailSupportedRenderers` renderer — the same renderer already used for the thumbnail URL one line below.
When `ucid` is still empty (e.g. collaboration videos with a composite channel name and no navigation endpoint), extract the first creator's channel ID from the `channelThumbnailSupportedRenderers` navigationEndpoint.
```
if author_id.empty?
  if channel_id = item_contents.dig?(
    "channelThumbnailSupportedRenderers",
    "channelThumbnailWithLinkRenderer",
    "navigationEndpoint",
    "browseEndpoint",
    "browseId"
  ).try &.as_s
    author_id = channel_id
  end
end
```

No template, API, or other parser changes needed - fixing `ucid` at the source automatically fixes both the HTML rendering (via `item.ecr:184`) and the JSON API (via `SearchVideo#to_json` which serializes `self.ucid` as `authorId`).

**Why this works**
The `channelThumbnailSupportedRenderers` renderer displays the `first creator's channel` avatar in the search result. To render that, YouTube includes the channel's `browseEndpoint` in the same renderer's `navigationEndpoint`.