### PR TITLE
Link hashtags in watch titles

### DIFF
--- a/spec/invidious/helpers_spec.cr
+++ b/spec/invidious/helpers_spec.cr
@@ -3,6 +3,36 @@ require "../spec_helper"
 CONFIG = Config.from_yaml(File.open("config/config.example.yml"))
 
 Spectator.describe "Helper" do
+  describe "#parse_video_title" do
+    it "links hashtags in video titles" do
+      expect(parse_video_title("Video title #music"))
+        .to eq(%(Video title <a href="/hashtag/music">#music</a>))
+    end
+
+    it "links hashtags after punctuation" do
+      expect(parse_video_title("Watch: #music"))
+        .to eq(%(Watch: <a href="/hashtag/music">#music</a>))
+    end
+
+    it "does not link hashes inside words" do
+      expect(parse_video_title("Video title test#music"))
+        .to eq("Video title test#music")
+    end
+
+    it "encodes unicode hashtags" do
+      hashtag = "\u{4E2D}\u{6587}"
+      punctuation = "\u{FF0C}"
+
+      expect(parse_video_title("Video ##{hashtag}#{punctuation}"))
+        .to eq(%(Video <a href="/hashtag/%E4%B8%AD%E6%96%87">##{hashtag}</a>#{punctuation}))
+    end
+
+    it "escapes video titles before linking hashtags" do
+      expect(parse_video_title(%(<b>#music</b> & #news)))
+        .to eq(%(&lt;b&gt;<a href="/hashtag/music">#music</a>&lt;/b&gt; &amp; <a href="/hashtag/news">#news</a>))
+    end
+  end
+
   describe "#produce_channel_search_continuation" do
     it "correctly produces token for searching a specific channel" do
       expect(produce_channel_search_continuation("UCXuqSBlHAE6Xw-yeJA0Tunw", "", 100)).to eq("4qmFsgJqEhhVQ1h1cVNCbEhBRTZYdy15ZUpBMFR1bncaIEVnWnpaV0Z5WTJnd0FUZ0JZQUY2QkVkS2IxaTRBUUE9WgCaAilicm93c2UtZmVlZFVDWHVxU0JsSEFFNlh3LXllSkEwVHVud3NlYXJjaA%3D%3D")

--- a/src/invidious/helpers/utils.cr
+++ b/src/invidious/helpers/utils.cr
@@ -20,6 +20,50 @@ def elapsed_text(elapsed)
   "#{(millis * 1000).round(2)}µs"
 end
 
+def parse_video_title(title : String) : String
+  title_chars = title.chars
+
+  return String.build(title.size) do |str|
+    index = 0
+
+    while index < title_chars.size
+      char = title_chars[index]
+
+      if char == '#' && video_title_hashtag_start?(title_chars, index)
+        hashtag_end = index + 1
+
+        while hashtag_end < title_chars.size && video_title_hashtag_char?(title_chars[hashtag_end])
+          hashtag_end += 1
+        end
+
+        hashtag = title_chars[(index + 1)...hashtag_end].join
+        url = URI.encode_path("/hashtag/#{hashtag}")
+
+        str << %(<a href="#{url}">)
+        str << HTML.escape("##{hashtag}")
+        str << "</a>"
+
+        index = hashtag_end
+      else
+        str << HTML.escape(char.to_s)
+        index += 1
+      end
+    end
+  end
+end
+
+private def video_title_hashtag_start?(title_chars : Array(Char), index : Int) : Bool
+  next_char = title_chars[index + 1]?
+  return false if next_char.nil?
+  return false unless video_title_hashtag_char?(next_char)
+
+  index == 0 || !video_title_hashtag_char?(title_chars[index - 1])
+end
+
+private def video_title_hashtag_char?(char : Char) : Bool
+  char == '_' || char.alphanumeric?
+end
+
 def decode_length_seconds(string)
   length_seconds = string.gsub(/[^0-9:]/, "")
   return 0_i32 if length_seconds.empty?

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -1,5 +1,6 @@
 <% ucid = video.ucid %>
 <% title = HTML.escape(video.title) %>
+<% title_html = parse_video_title(video.title) %>
 <% author = HTML.escape(video.author) %>
 
 
@@ -77,7 +78,7 @@ we're going to need to do it here in order to allow for translations.
 
 <div class="h-box">
     <h1>
-        <%= title %>
+        <%= title_html %>
         <% if params.listen %>
             <a title="<%=I18n.translate(locale, "Video mode")%>" id="link-iv-listen" data-base-url="/watch?<%= env.params.query %>&listen=0" href="/watch?<%= env.params.query %>&listen=0">
                 <i class="icon ion-ios-videocam"></i>


### PR DESCRIPTION
﻿## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**
OpenAI GPT-5 via Codex desktop app.

**Tool(s) used:**
OpenAI Codex desktop app, local git, GitHub CLI, GitHub API.

**How was AI used?**
AI assisted with triaging the issue, comparing the existing closed attempt, inspecting existing hashtag routing and watch title rendering, drafting the helper and focused specs, and preparing this PR description. I reviewed the diff before submitting.

---

## Pull request description

Fixes: #442

I want to be awarded the bounty associated to the issue this PR is fixing.

Invidious already has hashtag pages at `/hashtag/:hashtag`, but the visible watch-page video title is rendered as escaped plain text. This keeps title hashtags from being clickable even though the description parser already links hashtag endpoints.

### What changed

- Add `parse_video_title` to escape video titles while linking hashtag tokens to `/hashtag/<tag>`
- Use the parsed HTML only for the visible watch-page `<h1>` title
- Keep the existing escaped plain title for metadata, OpenGraph, Twitter cards, and the page `<title>`
- Add focused helper specs for basic linking, punctuation boundaries, word-boundary behavior, Unicode URL encoding, and HTML escaping

### Verification

- `git diff --check`
- Reviewed the rendered HTML output covered by the helper specs

I could not run `crystal spec` locally because this Windows environment does not have Crystal installed, and Docker/WSL are unavailable due the local virtualization platform being disabled. I am opening this as a draft so CI can run before marking it ready for review.
