### PR TITLE
Fix collaboration channel links in recommendations

### DIFF
--- a/spec/invidious/videos/related_videos_extract_spec.cr
+++ b/spec/invidious/videos/related_videos_extract_spec.cr
@@ -1,0 +1,51 @@
+require "../../parsers_helper.cr"
+
+Spectator.describe "parse_related_video" do
+  it "extracts the primary channel from collaboration bylines" do
+    related = JSON.parse(<<-JSON)
+      {
+        "videoId": "b2_vBMQmi3M",
+        "title": { "simpleText": "Alpha Beta Gamma" },
+        "shortBylineText": {
+          "runs": [{
+            "text": "Primary and Collaborator",
+            "navigationEndpoint": {
+              "showDialogCommand": {
+                "panelLoadingStrategy": {
+                  "inlineContent": {
+                    "dialogViewModel": {
+                      "customContent": {
+                        "listViewModel": {
+                          "listItems": [{
+                            "listItemViewModel": {
+                              "rendererContext": {
+                                "commandContext": {
+                                  "onTap": {
+                                    "innertubeCommand": {
+                                      "browseEndpoint": {
+                                        "browseId": "UClr4yKwH072yt1nUX29dQGg"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }]
+        }
+      }
+      JSON
+
+    parsed = Invidious::Videos::Parser.parse_related_video(related).not_nil!
+
+    expect(parsed["author"]).to eq("Primary and Collaborator")
+    expect(parsed["ucid"]).to eq("UClr4yKwH072yt1nUX29dQGg")
+  end
+end

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -1141,7 +1141,13 @@ module HelperExtractors
   # Retrieves the ID required for querying the InnerTube browse endpoint.
   # Returns an empty string when it's unable to do so
   def self.get_browse_id(container)
-    return container.dig?("navigationEndpoint", "browseEndpoint", "browseId").try &.as_s || ""
+    return container.dig?("navigationEndpoint", "browseEndpoint", "browseId").try &.as_s ||
+      container.dig?(
+        "navigationEndpoint", "showDialogCommand", "panelLoadingStrategy",
+        "inlineContent", "dialogViewModel", "customContent", "listViewModel",
+        "listItems", 0, "listItemViewModel", "rendererContext", "commandContext",
+        "onTap", "innertubeCommand", "browseEndpoint", "browseId"
+      ).try &.as_s || ""
   end
 end
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

- [ ] AI was not used to create this pull request
- [x] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**
OpenAI Codex (GPT-5)

**Tool(s) used:**
Codex desktop app

**How was AI used?**
Codex traced the collaboration byline payload, implemented the fallback, added the regression test, ran automated validation, and drafted this description. The account owner manually reviewed and validated the change before submission.

---

## Pull request description

Fixes: #5722

I want to be awarded the bounty associated to the issue this PR is fixing.

Collaboration recommendation bylines use a `showDialogCommand` instead of a direct `browseEndpoint`. `get_browse_id` therefore returned an empty ID, and the watch template rendered the author without a channel link.

This keeps the existing direct browse-ID path and falls back to the first collaborator's channel ID from the dialog payload. It also adds a focused regression test using the collaboration byline shape.

Validation:

- Full Crystal test suite: 165 examples, 0 failures
- Ameba on both changed files: 2 files, 0 failures
- API-only no-codegen compile: passed
- Manually reviewed and validated by the account owner
