### PR TITLE
fix(parser): link collaborative related videos

### DIFF
--- a/spec/invidious/videos/related_video_parser_spec.cr
+++ b/spec/invidious/videos/related_video_parser_spec.cr
@@ -1,0 +1,41 @@
+require "../../parsers_helper.cr"
+
+Spectator.describe Invidious::Videos::Parser do
+  it "uses the primary owner channel for collaborative related videos" do
+    related = JSON.parse(<<-JSON)
+      {
+        "videoId": "b2_vBMQmi3M",
+        "title": {"simpleText": "Collaborative video"},
+        "shortBylineText": {
+          "runs": [
+            {
+              "text": "D/V and FΛDE",
+              "navigationEndpoint": {
+                "showDialogCommand": {
+                  "panelLoadingStrategy": {
+                    "inlineContent": {}
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "channelThumbnailSupportedRenderers": {
+          "channelThumbnailWithLinkRenderer": {
+            "navigationEndpoint": {
+              "browseEndpoint": {
+                "browseId": "UClr4yKwH072yt1nUX29dQGg",
+                "canonicalBaseUrl": "/@DslashV"
+              }
+            }
+          }
+        }
+      }
+      JSON
+
+    result = Invidious::Videos::Parser.parse_related_video(related).not_nil!
+
+    expect(result["author"].as_s).to eq("D/V and FΛDE")
+    expect(result["ucid"].as_s).to eq("UClr4yKwH072yt1nUX29dQGg")
+  end
+end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -27,6 +27,13 @@ module Invidious::Videos::Parser
     author_verified = has_verified_badge?(related["ownerBadges"]?).to_s
 
     ucid = channel_info.try { |ci| HelperExtractors.get_browse_id(ci) }
+    if ucid.nil? || ucid.empty?
+      channel_renderer = related.dig?(
+        "channelThumbnailSupportedRenderers",
+        "channelThumbnailWithLinkRenderer"
+      )
+      ucid = channel_renderer.try { |renderer| HelperExtractors.get_browse_id(renderer) }
+    end
 
     short_view_count = related.try do |r|
       HelperExtractors.get_short_view_count(r).to_s


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

- [ ] AI was not used to create this pull request
- [x] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**

GPT-5.6-sol (reasoning model)

**Tool(s) used:**

Hermes Agent by Nous Research

**How was AI used?**

AI inspected the issue, related collaboration work, current parser, and live public InnerTube response structure; wrote the focused parser fallback and regression spec; and ran the automated validation listed below. A human has not yet performed the policy-required manual browser test, so this PR is intentionally a draft.

---

## Pull request description

Collaborative related-video bylines use a dialog command instead of a direct channel `browseEndpoint`. `parse_related_video` therefore kept the combined author text but emitted an empty `ucid`, leaving the author unlinked.

This change preserves the existing direct-byline lookup and, only when it yields no ID, falls back to the primary owner endpoint exposed by `channelThumbnailWithLinkRenderer`. The related-video data model supports one `ucid`, so the fallback chooses YouTube's primary owner while retaining the combined byline text.

A focused regression spec models the collaboration structure and verifies both the combined author and primary owner channel ID.

Fixes: #5722

I want to be awarded the bounty associated to the issue this PR is fixing.

## Automated testing

- `crystal spec spec/invidious/videos/related_video_parser_spec.cr` — 1 example, 0 failures
- `crystal spec` — 165 examples, 0 failures
- `crystal tool format --check src/invidious/videos/parser.cr spec/invidious/videos/related_video_parser_spec.cr` — passed
- `bin/ameba src/invidious/videos/parser.cr spec/invidious/videos/related_video_parser_spec.cr` — 2 files, 0 failures
- `crystal build --warnings all --error-on-warnings --stats --time --progress --error-trace src/invidious.cr` — passed on Crystal 1.20.3
- `git diff --check` — passed

Full-repository Ameba currently reports one formatting warning in unmodified `src/invidious/yt_backend/youtube_api.cr`; both changed files pass Ameba.

## Manual testing

- [ ] Human manual browser validation required by `AI_POLICY.md`

Suggested check after building this branch: open the #5722 reproduction video, find a collaborative recommendation, and verify that its combined creator byline links to the primary owner channel. The recommendations shown in the original report may rotate over time.
