### PR TITLE
fix(extractors): detect livestreams from the thumbnail time-status overlay

### DIFF
--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -159,8 +159,8 @@ private module Parsers
       # A livestream no longer necessarily carries a "LIVE" entry in `badges`.
       # On the trending feed — which is the livestreams feed since YouTube
       # removed the aggregated trending page — `badges` is absent altogether and
-      # the only marker is the thumbnail's time-status overlay, which reads
-      # `{"style": "LIVE", "text": "LIVE"}` in place of a duration.
+      # the only marker is the thumbnail's time-status overlay, which carries
+      # `{"style": "LIVE", "text": {"simpleText": "LIVE"}}` in place of a duration.
       #
       # Without this, every item on that feed is serialised as
       # `liveNow: false`, directly contradicting `/api/v1/videos` for the same

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -156,6 +156,22 @@ private module Parsers
         end
       end
 
+      # A livestream no longer necessarily carries a "LIVE" entry in `badges`.
+      # On the trending feed — which is the livestreams feed since YouTube
+      # removed the aggregated trending page — `badges` is absent altogether and
+      # the only marker is the thumbnail's time-status overlay, which reads
+      # `{"style": "LIVE", "text": "LIVE"}` in place of a duration.
+      #
+      # Without this, every item on that feed is serialised as
+      # `liveNow: false`, directly contradicting `/api/v1/videos` for the same
+      # video id. (`length_seconds` needs no equivalent fix: the overlay text is
+      # "LIVE", which `decode_length_seconds` already reduces to 0 — correct for
+      # a stream with no fixed duration.)
+      is_live_overlay = item_contents["thumbnailOverlays"]?.try &.as_a.any? do |overlay|
+        overlay.dig?("thumbnailOverlayTimeStatusRenderer", "style").try &.as_s == "LIVE"
+      end
+      badges |= VideoBadges::LiveNow if is_live_overlay
+
       SearchVideo.new({
         title:              title,
         id:                 video_id,


### PR DESCRIPTION
`VideoRendererParser` decides `liveNow` solely from a `"LIVE"` entry in `videoRenderer.badges`. YouTube no longer always sends one: on the trending feed `badges` is absent entirely, and the only live marker is the thumbnail's time-status overlay, which carries `{"style": "LIVE", "text": "LIVE"}` where a duration would otherwise be.

The result is that the list and detail endpoints contradict each other for the same video id.

This is especially visible because trending *is* the livestreams feed now — `fetch_trending` browses the livestreams channel because YouTube removed the aggregated trending page (#5397) — so in practice nearly every trending item is affected. It also affects Invidious' own web UI, which renders the same `liveNow`.

## Reproduction

Against an instance at `9d1291a0`, region NL:

```
$ curl -s '<instance>/api/v1/trending?region=NL' | jq -r '.[] | "\(.videoId) liveNow=\(.liveNow)"'
BRha0tJtI8s liveNow=false
qEcVsczCkBw liveNow=false
...

$ curl -s '<instance>/api/v1/videos/BRha0tJtI8s' | jq .liveNow
true
```

**14 of 15** trending items disagreed with their own detail endpoint. After the patch, **0 of 15**.

The raw InnerTube payload for those items shows why — no `badges` key at all:

```json
{
  "videoId": "BRha0tJtI8s",
  "badges": null,
  "lengthText": null,
  "thumbnailOverlays": [
    { "thumbnailOverlayTimeStatusRenderer": { "style": "LIVE", "text": { "simpleText": "LIVE" } } }
  ],
  "viewCountText": { "simpleText": "6,091 watching" }
}
```

## Notes for reviewers

- Existing `badges` parsing is untouched; the overlay is read as an **additional** source, so `liveNow` still comes from a `"LIVE"` badge wherever YouTube sends one.
- `length_seconds` deliberately needs no equivalent change: the overlay text is `"LIVE"`, which `decode_length_seconds` already reduces to `0` — correct for a stream with no fixed duration.
- **No false positives found.** A channel's videos tab (60 items), search (20, of which 2 genuinely live) and popular (40) were all unchanged by the patch, cross-checked per item against `/api/v1/videos`.
- `crystal tool format --check` clean.
- **Overlaps with #5846** (`feat(api): expose isShort on list items`). Both insert
  a `thumbnailOverlays` read immediately after the `badges` loop in
  `VideoRendererParser`. Each branch applies cleanly to `master` on its own, but
  whichever merges second will need a one-hunk rebase — happy to do that whenever
  you like. They are independent changes, so they are offered separately rather
  than bundled.

## AI disclosure (per `AI_POLICY.md`)

This patch was written with AI assistance.

- **Exact model:** Claude Opus 5 — model ID `claude-opus-5[1m]`
- **Tool used to interact with it:** Claude Code, Anthropic's agentic CLI

How it was checked, stated precisely so you can judge it: the JSON path was not guessed — the raw InnerTube `browse` payload was fetched and inspected to find where the live marker had moved. The patch was then built, deployed to a live instance, and the before/after numbers above were measured on live data, including the false-positive check across three other endpoints. It is running in production on my instance.

I am the submitter and, per the policy, solely responsible for this change. Happy to run any further test you would like before merge.