### PR TITLE
Fix auto-generated channel header parsing

### DIFF
--- a/spec/invidious/channels/about_spec.cr
+++ b/spec/invidious/channels/about_spec.cr
@@ -1,0 +1,86 @@
+require "../../../src/invidious/exceptions"
+require "../../spec_helper"
+
+Spectator.describe "extract_auto_generated_channel_header" do
+  it "parses the current pageHeaderRenderer shape" do
+    initdata = JSON.parse(<<-JSON).as_h
+      {
+        "header": {
+          "pageHeaderRenderer": {
+            "pageTitle": "Gaming",
+            "content": {
+              "pageHeaderViewModel": {
+                "title": {
+                  "dynamicTextViewModel": {
+                    "text": {"content": "Gaming"}
+                  }
+                },
+                "animatedImage": {
+                  "contentPreviewImageViewModel": {
+                    "image": {
+                      "sources": [
+                        {"url": "//yt3.example/avatar-48", "width": 48, "height": 48}
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      JSON
+
+    header = extract_auto_generated_channel_header(initdata, "UCOpNcN46UbXVtpKMrmU4Abg")
+
+    expect(header[:author]).to eq("Gaming")
+    expect(header[:author_url]).to eq("https://www.youtube.com/channel/UCOpNcN46UbXVtpKMrmU4Abg")
+    expect(header[:author_thumbnail]).to eq("//yt3.example/avatar-48")
+    expect(header[:banner]).to be_nil
+    expect(header[:description_node]).to be_nil
+    expect(header[:tags]).to be_empty
+    expect(header[:is_family_friendly]).to be_true
+  end
+
+  it "preserves the legacy interactiveTabbedHeaderRenderer shape" do
+    initdata = JSON.parse(<<-JSON).as_h
+      {
+        "header": {
+          "interactiveTabbedHeaderRenderer": {
+            "title": {"simpleText": "Legacy gaming"},
+            "boxArt": {
+              "thumbnails": [
+                {"url": "https://yt3.example/legacy-avatar"}
+              ]
+            },
+            "banner": {
+              "thumbnails": [
+                {"url": "https://yt3.example/legacy-banner"}
+              ]
+            },
+            "description": {"simpleText": "Legacy description"},
+            "badges": [
+              {"metadataBadgeRenderer": {"label": "Verified"}}
+            ]
+          }
+        },
+        "microformat": {
+          "microformatDataRenderer": {
+            "urlCanonical": "https://www.youtube.com/channel/legacy",
+            "familySafe": false
+          }
+        }
+      }
+      JSON
+
+    header = extract_auto_generated_channel_header(initdata, "legacy")
+
+    expect(header[:author]).to eq("Legacy gaming")
+    expect(header[:author_url]).to eq("https://www.youtube.com/channel/legacy")
+    expect(header[:author_thumbnail]).to eq("https://yt3.example/legacy-avatar")
+    expect(header[:banner]).to eq("https://yt3.example/legacy-banner")
+    expect(header[:description_node].try &.as_s).to eq("Legacy description")
+    expect(header[:tags]).to eq(["Verified"])
+    expect(header[:is_family_friendly]).to be_false
+  end
+end

--- a/spec/invidious/yt_backend/extractors_spec.cr
+++ b/spec/invidious/yt_backend/extractors_spec.cr
@@ -1,0 +1,22 @@
+require "../../parsers_helper"
+
+Spectator.describe "YouTubeTabs" do
+  it "treats a selected tab without content as empty" do
+    initdata = JSON.parse(<<-JSON).as_h
+      {
+        "contents": {
+          "twoColumnBrowseResultsRenderer": {
+            "tabs": [
+              {"tabRenderer": {"selected": true}}
+            ]
+          }
+        }
+      }
+      JSON
+
+    items, continuation = extract_items(initdata)
+
+    expect(items).to be_empty
+    expect(continuation).to be_nil
+  end
+end

--- a/src/invidious/channels/about.cr
+++ b/src/invidious/channels/about.cr
@@ -19,6 +19,55 @@ record AboutChannel,
   verified : Bool,
   is_age_gated : Bool
 
+def extract_auto_generated_channel_header(initdata : Hash(String, JSON::Any), ucid : String)
+  if header = initdata.dig?("header", "interactiveTabbedHeaderRenderer")
+    author = header.dig("title", "simpleText").as_s
+    author_url = initdata.dig("microformat", "microformatDataRenderer", "urlCanonical").as_s
+    author_thumbnail = header.dig("boxArt", "thumbnails", 0, "url").as_s
+
+    banners = header.dig?("banner", "thumbnails")
+    banner = banners.try &.as_a[-1]?.try &.dig?("url").try &.as_s
+
+    description_base_node = header["description"]
+    description_node = description_base_node.dig?("simpleText") || description_base_node
+
+    tags = header["badges"]?
+      .try &.as_a.map(&.dig("metadataBadgeRenderer", "label").as_s) || [] of String
+  elsif header = initdata.dig?("header", "pageHeaderRenderer")
+    header_view = header.dig?("content", "pageHeaderViewModel")
+
+    author = header_view.try &.dig?("title", "dynamicTextViewModel", "text", "content").try &.as_s
+    author ||= header["pageTitle"]?.try &.as_s
+    author ||= ucid
+
+    author_url = "https://www.youtube.com/channel/#{ucid}"
+    author_thumbnail = header_view.try &.dig?("animatedImage", "contentPreviewImageViewModel", "image", "sources", 0, "url").try &.as_s
+    author_thumbnail ||= header_view.try &.dig?("image", "decoratedAvatarViewModel", "avatar", "avatarViewModel", "image", "sources", 0, "url").try &.as_s
+    author_thumbnail ||= ""
+
+    banners = header_view.try &.dig?("banner", "imageBannerViewModel", "image", "sources")
+    banner = banners.try &.as_a[-1]?.try &.dig?("url").try &.as_s
+
+    description_node = header_view.try &.dig?("description", "descriptionPreviewViewModel", "description", "content")
+    tags = [] of String
+  else
+    raise InfoException.new("Could not extract channel header.")
+  end
+
+  family_safe = initdata.dig?("microformat", "microformatDataRenderer", "familySafe").try &.as_bool
+  is_family_friendly = family_safe.nil? ? true : family_safe
+
+  {
+    author:             author,
+    author_url:         author_url,
+    author_thumbnail:   author_thumbnail,
+    banner:             banner,
+    description_node:   description_node,
+    tags:               tags,
+    is_family_friendly: is_family_friendly,
+  }
+end
+
 def get_about_info(ucid, locale) : AboutChannel
   begin
     # Fetch channel information from channel home page
@@ -50,6 +99,8 @@ def get_about_info(ucid, locale) : AboutChannel
   tab_names = [] of String
   total_views = 0_i64
   joined = Time.unix(0)
+  author_verified = false
+  is_age_gated = false
 
   if age_gate_renderer = initdata.dig?("contents", "twoColumnBrowseResultsRenderer", "tabs", 0, "tabRenderer", "content", "sectionListRenderer", "contents", 0, "channelAgeGateRenderer")
     description_node = nil
@@ -64,21 +115,14 @@ def get_about_info(ucid, locale) : AboutChannel
     auto_generated = false
   else
     if auto_generated
-      author = initdata["header"]["interactiveTabbedHeaderRenderer"]["title"]["simpleText"].as_s
-      author_url = initdata["microformat"]["microformatDataRenderer"]["urlCanonical"].as_s
-      author_thumbnail = initdata["header"]["interactiveTabbedHeaderRenderer"]["boxArt"]["thumbnails"][0]["url"].as_s
-
-      # Raises a KeyError on failure.
-      banners = initdata["header"]["interactiveTabbedHeaderRenderer"]?.try &.["banner"]?.try &.["thumbnails"]?
-      banner = banners.try &.[-1]?.try &.["url"].as_s?
-
-      description_base_node = initdata["header"]["interactiveTabbedHeaderRenderer"]["description"]
-      # some channels have the description in a simpleText
-      # ex: https://www.youtube.com/channel/UCQvWX73GQygcwXOTSf_VDVg/
-      description_node = description_base_node.dig?("simpleText") || description_base_node
-
-      tags = initdata.dig?("header", "interactiveTabbedHeaderRenderer", "badges")
-        .try &.as_a.map(&.["metadataBadgeRenderer"]["label"].as_s) || [] of String
+      channel_header = extract_auto_generated_channel_header(initdata, ucid)
+      author = channel_header[:author]
+      author_url = channel_header[:author_url]
+      author_thumbnail = channel_header[:author_thumbnail]
+      banner = channel_header[:banner]
+      description_node = channel_header[:description_node]
+      tags = channel_header[:tags]
+      is_family_friendly = channel_header[:is_family_friendly]
     else
       author = initdata["metadata"]["channelMetadataRenderer"]["title"].as_s
       author_url = initdata["metadata"]["channelMetadataRenderer"]["channelUrl"].as_s
@@ -103,9 +147,9 @@ def get_about_info(ucid, locale) : AboutChannel
 
       description_node = initdata["metadata"]["channelMetadataRenderer"]?.try &.["description"]?
       tags = initdata.dig?("microformat", "microformatDataRenderer", "tags").try &.as_a.map(&.as_s) || [] of String
+      is_family_friendly = initdata["microformat"]["microformatDataRenderer"]["familySafe"].as_bool
     end
 
-    is_family_friendly = initdata["microformat"]["microformatDataRenderer"]["familySafe"].as_bool
     if tabs_json = initdata["contents"]["twoColumnBrowseResultsRenderer"]["tabs"]?
       # Get the name of the tabs available on this channel
       tab_names = tabs_json.as_a.compact_map do |entry|

--- a/src/invidious/channels/about.cr
+++ b/src/invidious/channels/about.cr
@@ -51,7 +51,7 @@ def extract_auto_generated_channel_header(initdata : Hash(String, JSON::Any), uc
     description_node = header_view.try &.dig?("description", "descriptionPreviewViewModel", "description", "content")
     tags = [] of String
   else
-    raise InfoException.new("Could not extract channel header.")
+    raise InfoException.new("Could not extract channel header for #{ucid}: expected interactiveTabbedHeaderRenderer or pageHeaderRenderer.")
   end
 
   family_safe = initdata.dig?("microformat", "microformatDataRenderer", "familySafe").try &.as_bool

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -964,7 +964,8 @@ private module Extractors
 
     private def self.extract(target)
       raw_items = [] of JSON::Any
-      content = extract_selected_tab(target["tabs"])["content"]
+      content = extract_selected_tab(target["tabs"])["content"]?
+      return raw_items if content.nil?
 
       if section_list_contents = content.dig?("sectionListRenderer", "contents")
         raw_items = unpack_section_list(section_list_contents)


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**

OpenAI GPT-5 (Codex)

**Tool(s) used:**

OpenAI Codex desktop app

**How was AI used?**

AI assisted with source analysis, implementation, and regression-test drafting. I manually reviewed and tested the changes.

---

## Pull request description

Fixes: #2137

I want to be awarded the bounty associated to the issue this PR is fixing.

YouTube's current payload for auto-generated channels uses `pageHeaderRenderer` rather than the legacy `interactiveTabbedHeaderRenderer`. This change:

- parses the current `pageHeaderRenderer` title and avatar shape while retaining the legacy path;
- supplies safe fallbacks for optional auto-generated-channel metadata;
- preserves an explicit `familySafe: false` value while defaulting only missing metadata;
- treats a selected YouTube tab without `content` as an empty result instead of raising another `KeyError`;
- adds focused regression coverage for the current and legacy header shapes and the empty selected-tab payload.

### Validation

- Crystal formatter: passed
- Focused regression suite: 3 examples, 0 failures
- Full test suite: 167 examples, 0 failures
- Exact production Docker image: built successfully
- Live local target route: HTTP 200 with title `Gaming - Invidious`, visible Gaming channel data, and no error template
- Live local API route: HTTP 200
- Human code review and manual browser validation: completed before submission

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change updates parsing for YouTube’s current channel-header format while preserving legacy channel support and allowing selected tabs with no content. A reproduced failure remains in the new header path: when YouTube supplies neither supported avatar representation, the channel response exposes empty thumbnail URLs to API consumers. Merge should wait until the missing-avatar path returns a usable fallback or omits unusable thumbnail entries.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not ready to merge because channels without either recognized avatar shape return unusable thumbnail URLs.

A focused Crystal reproduction exercised an avatar-absent current channel header through the production extractor and the API thumbnail formatting path, observing an empty source thumbnail and empty URLs for every advertised size.

**Files Needing Attention:** `src/invidious/channels/about.cr` needs a safe behavior for missing avatar sources; `src/invidious/routes/api/v1/channels.cr` currently propagates the empty value into API responses.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a finding-comment-proof for a posted P1 finding and attached three artifacts documenting the focused reproduction, the output with empty thumbnail URLs, and the existing channel header spec.
- T-Rex produced a second finding-comment-proof for another P1 finding; no artifacts were attached.
- T-Rex produced a general-contract-validation-proof showing that author\_thumbnail.empty? is true and api\_all\_urls\_empty is true, traced to the empty fallback in about.cr and the lack of a fallback in channels API, with no production code changes made.

<a href="https://app.greptile.com/trex/runs/18362105/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Avatar-absent generated channels expose empty thumbnail URLs**

   - **Bug**
     - For a `pageHeaderRenderer` whose `pageHeaderViewModel` has neither `animatedImage` nor `image.decoratedAvatarViewModel`, header extraction returns an empty thumbnail. API v1 generates six `authorThumbnails` entries, each with `url: ""`, so clients receive unusable channel-thumbnail URLs.
   - **Cause**
     - `src/invidious/channels/about.cr:46` uses `author_thumbnail ||= ""`; the API formatter at `src/invidious/routes/api/v1/channels.cr:85` only rewrites an existing size suffix and leaves the empty value unchanged.
   - **Fix**
     - Provide a non-empty safe fallback thumbnail URL, or omit `authorThumbnails` when no source URL exists, rather than emitting six empty URLs.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Improve channel header extraction error"](https://github.com/iv-org/invidious/commit/1b727487983dfe881291db45b39d38d8e1c30ec8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51303560)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->