### PR TITLE
CI: Exclude development dependencies from build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,7 @@ jobs:
       - name: Install Shards
         run: |
           if ! shards check; then
-            shards install --production
-            shards install spectator --frozen
+            shards install --skip-postinstall --skip-executables
           fi
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
       - name: Install Shards
         run: |
           if ! shards check; then
-            shards install --without-development
+            shards install --production
+            shards install spectator --frozen
           fi
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install Shards
         run: |
           if ! shards check; then
-            shards install
+            shards install --without-development
           fi
 
       - name: Run tests


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

The build CI to test if Invidious builds without problems on certain Crystal versions do not really need to install development dependencies like Ameba to build Invidious, so we skip the installation of them.