### PR TITLE
fix: fix comments html rendering

### DIFF
--- a/src/invidious/comments/youtube.cr
+++ b/src/invidious/comments/youtube.cr
@@ -155,17 +155,7 @@ module Invidious::Comments
                     json.field "authorUrl", "/channel/#{comment_author["channelId"].as_s}"
                     json.field "author", comment_author["displayName"].as_s
                     json.field "verified", comment_author["isVerified"].as_bool
-                    json.field "authorThumbnails" do
-                      json.array do
-                        comment_mutation.dig?("payload", "commentEntityPayload", "avatar", "image", "sources").try &.as_a.each do |thumbnail|
-                          json.object do
-                            json.field "url", thumbnail["url"]
-                            json.field "width", thumbnail["width"]
-                            json.field "height", thumbnail["height"]
-                          end
-                        end
-                      end
-                    end
+                    json.field "authorThumbnail", comment_author["avatarThumbnailUrl"].as_s
 
                     json.field "authorIsChannelOwner", comment_author["isCreator"].as_bool
                     json.field "isSponsor", (comment_author["sponsorBadgeUrl"]? != nil)

--- a/src/invidious/frontend/comments_youtube.cr
+++ b/src/invidious/frontend/comments_youtube.cr
@@ -44,7 +44,7 @@ module Invidious::Frontend::Comments
         end
 
         if !thin_mode
-          author_thumbnail = "/ggpht#{URI.parse(child["authorThumbnails"][-1]["url"].as_s).request_target}"
+          author_thumbnail = "/ggpht#{URI.parse(child["authorThumbnail"].as_s).request_target}"
         else
           author_thumbnail = ""
         end


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

Now the structure no longer has an array of author thumbnails, is a single URL:

```json
"author": {
    "channelId": "UCiLGHgWdQvfl1G8BPgcO55w",
    "displayName": "@uber_nerd-l7r",
    "avatarThumbnailUrl": "https://yt3.ggpht.com/ee1_iFgiBvgKHUr3r0_qUVqUpGKhDZaePYq8Q4tIsyVS9L1oRHHJLcHtXrSxyS63AmvldKicbw=s88-c-k-c0x00ffffff-no-rj",
    "isVerified": false,
    "isCurrentUser": false,
    "isCreator": false,
```

Closes https://github.com/iv-org/invidious/issues/5854