### PR TITLE
Fix UTF-16 offsets in video description commands

### DIFF
--- a/spec/invidious/videos/description_spec.cr
+++ b/spec/invidious/videos/description_spec.cr
@@ -1,0 +1,90 @@
+require "../../spec_helper"
+require "../../../src/invidious/videos/description"
+
+Spectator.describe "Video description parser" do
+  describe "#parse_description" do
+    it "uses UTF-16 offsets when an emoji precedes a command" do
+      description = JSON.parse(<<-JSON)
+        {
+          "content": "🚀 Visit example now",
+          "commandRuns": [{
+            "startIndex": 3,
+            "length": 5,
+            "onTap": {
+              "innertubeCommand": {
+                "urlEndpoint": {"url": "https://example.com"}
+              }
+            }
+          }]
+        }
+        JSON
+
+      expect(parse_description(description, "video-id")).to eq(
+        %(🚀 <a href="https://example.com">Visit</a> example now)
+      )
+    end
+
+    it "uses UTF-16 lengths when an emoji is inside a command" do
+      description = JSON.parse(<<-JSON)
+        {
+          "content": "Open 😀 docs",
+          "commandRuns": [{
+            "startIndex": 0,
+            "length": 7,
+            "onTap": {
+              "innertubeCommand": {
+                "urlEndpoint": {"url": "https://example.com"}
+              }
+            }
+          }]
+        }
+        JSON
+
+      expect(parse_description(description, "video-id")).to eq(
+        %(<a href="https://example.com">Open 😀</a> docs)
+      )
+    end
+
+    it "continues to count basic multilingual plane characters once" do
+      description = JSON.parse(<<-JSON)
+        {
+          "content": "Café link",
+          "commandRuns": [{
+            "startIndex": 5,
+            "length": 4,
+            "onTap": {
+              "innertubeCommand": {
+                "urlEndpoint": {"url": "https://example.com"}
+              }
+            }
+          }]
+        }
+        JSON
+
+      expect(parse_description(description, "video-id")).to eq(
+        %(Café <a href="https://example.com">link</a>)
+      )
+    end
+
+    it "escapes HTML around and inside commands" do
+      description = JSON.parse(<<-JSON)
+        {
+          "content": "🚀 <click> & end",
+          "commandRuns": [{
+            "startIndex": 3,
+            "length": 7,
+            "onTap": {
+              "innertubeCommand": {
+                "urlEndpoint": {"url": "https://example.com"}
+              }
+            }
+          }]
+        }
+        JSON
+
+      expect(parse_description(description, "video-id")).to eq(
+        %(🚀 <a href="https://example.com">&lt;click&gt;</a> &amp; end)
+      )
+    end
+  end
+end

--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -1,7 +1,16 @@
 require "json"
 require "uri"
 
-private def copy_string(str : String::Builder, iter : Iterator, count : Int) : Int
+private def utf16_length(str : String) : Int32
+  length = 0
+  str.each_codepoint do |cp|
+    length += cp > 0xFFFF ? 2 : 1
+  end
+
+  return length
+end
+
+private def copy_string(str : String::Builder, iter : Iterator, count : Int, *, utf16 : Bool = false) : Int
   copied = 0
   while copied < count
     cp = iter.next
@@ -21,7 +30,9 @@ private def copy_string(str : String::Builder, iter : Iterator, count : Int) : I
       str << cp.chr
     end
 
-    copied += 1
+    # YouTube's command offsets use UTF-16 code units. Characters outside the
+    # basic multilingual plane (such as most emoji) occupy two such units.
+    copied += (utf16 && cp > 0xFFFF) ? 2 : 1
   end
 
   return copied
@@ -53,12 +64,12 @@ def parse_description(desc, video_id : String) : String?
 
       # Copy the text chunk between this command and the previous if needed.
       length = cmd_start - index
-      index += copy_string(str, iter, length)
+      index += copy_string(str, iter, length, utf16: true)
 
       # We need to copy the command's text using the iterator
       # and the special function defined above.
       cmd_content = String.build(cmd_length) do |str2|
-        copy_string(str2, iter, cmd_length)
+        copy_string(str2, iter, cmd_length, utf16: true)
       end
 
       link = cmd_content
@@ -70,7 +81,7 @@ def parse_description(desc, video_id : String) : String?
     end
 
     # Copy the end of the string (past the last command).
-    remaining_length = content.size - index
-    copy_string(str, iter, remaining_length) if remaining_length > 0
+    remaining_length = utf16_length(content) - index
+    copy_string(str, iter, remaining_length, utf16: true) if remaining_length > 0
   end
 end


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

- [ ] AI was not used to create this pull request
- [x] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**
OpenAI Codex (GPT-5)

**Tool(s) used:**
Codex desktop app with in-app browser and shell, Crystal 1.21.0, and Zig 0.16.0

**How was AI used?**
Codex investigated the issue, reproduced the UTF-16/codepoint offset mismatch against the referenced YouTube description, implemented the fix, added regression tests, formatted the changed files, and ran a focused Crystal runtime harness. The account owner reviewed the policy and authorized the submission.

---

## Pull request description

YouTube reports attributed-description command positions in UTF-16 code units. Invidious previously advanced its iterator by Unicode codepoints, so every astral character before a command shifted the rendered link.

This change:
- counts astral codepoints as two units when consuming command offsets and lengths;
- preserves the existing single-pass escaping behavior;
- adds focused coverage for emoji before and inside commands, BMP characters, and HTML escaping.

Validation:
- `crystal tool format --check` passed for both changed files.
- Four focused Crystal runtime cases passed locally.
- The full project suite is left to GitHub CI because the local macOS environment lacks Apple Command Line Tools.

Fixes: #5821

I want to be awarded the bounty associated to the issue this PR is fixing.