### PR TITLE
fix: skip non comment `commentFilterContextViewModel` key in comments

### DIFF
--- a/src/invidious/comments/youtube.cr
+++ b/src/invidious/comments/youtube.cr
@@ -128,6 +128,8 @@ module Invidious::Comments
         json.field "comments" do
           json.array do
             contents.as_a.each do |node|
+              next if node["commentFilterContextViewModel"]?
+
               json.object do
                 if node["commentThreadRenderer"]?
                   node = node["commentThreadRenderer"]


### PR DESCRIPTION


## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

Some youtube videos like https://www.youtube.com/watch?v=Ajkr_Wg-k8g had an non comment key that was inside the Array that contained some comment information that Invidious parses (like comment_key and toolbar_key), that being the `commentFilterContextViewModel` key, which is just an indicator on how comments are sorted:

```
{
    "commentThreadRenderer": { ... } <- comment information that is
    handled by line 134 of youtube.cr
},
{
    "commentFilterContextViewModel": {
        "text": {
            "content": "Top is selected, so you'll see featured comments"
        },
        "accessibility": {
            "accessibilityData": {
                "label": "Top is selected, so you'll see featured comments"
            }
        }
    } <- Useless information, this is not a comment
}
```

Closes https://github.com/iv-org/invidious/issues/5854 again