### PR TITLE
fix: make clip api less expensive

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -460,7 +460,6 @@ feed_threads: 1
 ##
 ## Notes: The following API endpoints will be disabled:
 ##  - /api/v1/videos
-##  - /api/v1/clips
 ##  - /api/v1/transcripts
 ##
 ## Accepted values: true, false

--- a/src/invidious/helpers/handlers.cr
+++ b/src/invidious/helpers/handlers.cr
@@ -136,7 +136,7 @@ end
 class DisableAbusableAPIHandler < Kemal::Handler
   {% for method in %w(GET HEAD) %}
     # This endpoints make a video request to Invidious companion.
-    {% for endpoint in %w(videos clips transcripts) %}
+    {% for endpoint in %w(videos transcripts) %}
       only ["/api/v1/{{ endpoint.id }}/:id"], {{ method }}
     {% end %}
   {% end %}

--- a/src/invidious/routes/api/v1/videos.cr
+++ b/src/invidious/routes/api/v1/videos.cr
@@ -413,22 +413,12 @@ module Invidious::Routes::API::V1::Videos
       start_time, end_time, clip_title = Invidious::Videos::Clip.parse_clip_parameters(params)
     end
 
-    begin
-      video = get_video(video_id, region: region)
-    rescue ex : NotFoundException
-      return error_json(404, ex)
-    rescue ex
-      return error_json(500, ex)
-    end
-
     return JSON.build do |json|
       json.object do
         json.field "startTime", start_time
         json.field "endTime", end_time
         json.field "clipTitle", clip_title
-        json.field "video" do
-          Invidious::JSONify::APIv1.video(video, json, locale: locale, proxy: proxy)
-        end
+        json.field "videoId", video_id
       end
     end
   end


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

- [x] AI was not used to create this pull request

## Pull request description

I added the clip api endpoint to Invidious for FreeTube to use and am now finally getting around to adding support in FreeTube.

The endpoint is unnecessarily expensive for no good reason with the `get_video` call so this PR replaces it with just the video_id instead. I haven't been able to find a client that uses this endpoint but would like to use it in FreeTube as part of: https://github.com/FreeTubeApp/FreeTube/pull/9532


## Testing

`{INVIDIOUS API}/api/v1/clips/UgkxxPM3BRphCAPLP88YoUGuj79KXPfpNNO_`