### PR TITLE
chore: remove `-Dpreview_mt` from Makefile as it has been deprecated by the Crystal compiler.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,6 @@ ifeq ($(STATIC), 1)
   FLAGS += --static
 endif
 
-ifeq ($(MT), 1)
-  FLAGS += -Dpreview_mt
-endif
-
-
 ifeq ($(NO_DBG_SYMBOLS), 1)
   FLAGS += --no-debug
 else


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

Crystal 1.21.0 now features execution contexts, they do not longer support (and recommend) the `-Dpreview_mt` build flag. `-Dpreview_mt` also worked really bad and it made Invidious to hang on high load, so it was never useful.

https://crystal-lang.org/2026/07/16/1.21.0-released/#execution-contexts