### PR TITLE
fix: also fix comments in community posts

### DIFF
--- a/src/invidious/frontend/comments_youtube.cr
+++ b/src/invidious/frontend/comments_youtube.cr
@@ -44,7 +44,11 @@ module Invidious::Frontend::Comments
         end
 
         if !thin_mode
-          author_thumbnail = "/ggpht#{URI.parse(child["authorThumbnail"].as_s).request_target}"
+          if child_author_thumbnail = child["authorThumbnail"]?.try &.as_s
+            author_thumbnail = "/ggpht#{URI.parse(child_author_thumbnail).request_target}"
+          else
+            author_thumbnail = "/ggpht#{URI.parse(child["authorThumbnails"][-1]["url"].as_s).request_target}"
+          end
         else
           author_thumbnail = ""
         end


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

Community posts comments still preserve the old author thumbnails format that has an Array of thumbnails. I forgot to check that as I had no idea `comments_youtube.cr` was also used for community posts comments.

```json
"authorThumbnail": {
    "thumbnails": [
        {
            "url": "//yt3.googleusercontent.com/ytc/AIdro_m9CJFVl3bEWvGnNnN4G9ErBO2lTpKePWCjx_FQtLWaDww=s32-c-k-c0x00ffffff-no-rj-mo",
            "width": 32,
            "height": 32
        },
        {
            "url": "//yt3.googleusercontent.com/ytc/AIdro_m9CJFVl3bEWvGnNnN4G9ErBO2lTpKePWCjx_FQtLWaDww=s48-c-k-c0x00ffffff-no-rj-mo",
            "width": 48,
            "height": 48
        },
        {
            "url": "//yt3.googleusercontent.com/ytc/AIdro_m9CJFVl3bEWvGnNnN4G9ErBO2lTpKePWCjx_FQtLWaDww=s76-c-k-c0x00ffffff-no-rj-mo",
            "width": 76,
            "height": 76
        }
    ],
    "accessibility": {
        "accessibilityData": {
            "label": "SomeOrdinaryGamers"
        }
    }
},
```