### PR TITLE
fix: use UTF-16 offsets for description links

### DIFF
--- a/spec/invidious/videos/description_spec.cr
+++ b/spec/invidious/videos/description_spec.cr
@@ -1,0 +1,56 @@
+require "../../spec_helper"
+require "../../../src/invidious/videos/description"
+
+Spectator.describe "Video description parser" do
+  describe "#parse_description" do
+    it "uses UTF-16 offsets when an emoji precedes a command" do
+      description = JSON.parse(<<-JSON)
+        {
+          "content": "🚀 Visit example now",
+          "commandRuns": [{
+            "startIndex": 3,
+            "length": 5,
+            "onTap": {
+              "innertubeCommand": {
+                "urlEndpoint": {"url": "https://example.com"}
+              }
+            }
+          }]
+        }
+        JSON
+
+      expect(parse_description(description, "video-id")).to eq(
+        %(🚀 <a href="https://example.com">Visit</a> example now)
+      )
+    end
+
+    it "uses UTF-16 lengths when an emoji is inside a command" do
+      description = JSON.parse(<<-JSON)
+        {
+          "content": "Open 😀 docs",
+          "commandRuns": [{
+            "startIndex": 0,
+            "length": 7,
+            "onTap": {
+              "innertubeCommand": {
+                "urlEndpoint": {"url": "https://example.com"}
+              }
+            }
+          }]
+        }
+        JSON
+
+      expect(parse_description(description, "video-id")).to eq(
+        %(<a href="https://example.com">Open 😀</a> docs)
+      )
+    end
+
+    it "escapes complete descriptions without command runs" do
+      description = JSON.parse(%({"content":"🚀 <safe> & complete"}))
+
+      expect(parse_description(description, "video-id")).to eq(
+        %(🚀 &lt;safe&gt; &amp; complete)
+      )
+    end
+  end
+end

--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -1,9 +1,9 @@
 require "json"
 require "uri"
 
-private def copy_string(str : String::Builder, iter : Iterator, count : Int) : Int
+private def copy_string(str : String::Builder, iter : Iterator, count : Int? = nil) : Int
   copied = 0
-  while copied < count
+  while count.nil? || copied < count
     cp = iter.next
     break if cp.is_a?(Iterator::Stop)
 
@@ -21,7 +21,9 @@ private def copy_string(str : String::Builder, iter : Iterator, count : Int) : I
       str << cp.chr
     end
 
-    copied += 1
+    # YouTube expresses command offsets in UTF-16 code units. Astral
+    # codepoints therefore count as two units instead of one.
+    copied += cp > 0xFFFF ? 2 : 1
   end
 
   return copied
@@ -38,7 +40,7 @@ def parse_description(desc, video_id : String) : String?
     # Slightly faster than HTML.escape, as we're only doing one pass on
     # the string instead of five for the standard library
     return String.build do |str|
-      copy_string(str, content.each_codepoint, content.size)
+      copy_string(str, content.each_codepoint)
     end
   end
 
@@ -70,7 +72,6 @@ def parse_description(desc, video_id : String) : String?
     end
 
     # Copy the end of the string (past the last command).
-    remaining_length = content.size - index
-    copy_string(str, iter, remaining_length) if remaining_length > 0
+    copy_string(str, iter)
   end
 end


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

- [ ] AI was not used to create this pull request
- [x] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**

OpenAI `codex/gpt-5.6-sol` (high reasoning)

**Tool(s) used:**

OpenAI Codex through OpenClaw, with shell access and the Crystal 1.20.3/1.21.0 toolchains

**How was AI used?**

Codex traced the regression through the Git history, created the Crystal change and regression tests, and ran the automated checks. I read the AI policy before the change was prepared. I then manually reviewed the complete diff and the visual verification described below, and I accept responsibility for the contribution.

---

## Pull request description

Fixes: #5821

YouTube expresses `attributedDescription.commandRuns` offsets and lengths in UTF-16 code units. The parser was advancing the description iterator by Unicode codepoints, so astral characters such as emoji shifted every later command boundary.

This change:

- counts astral codepoints as two units while consuming command offsets and lengths;
- copies unbounded text to iterator exhaustion, avoiding a mix of UTF-16 command indices and Crystal's codepoint-based `String#size`;
- keeps the existing single-pass HTML escaping;
- adds focused regression coverage for emoji before a command, emoji inside a command, trailing text, and command-free descriptions.

Automated verification:

- on unpatched `ad4b1c69`, the two UTF-16 regression examples fail with the exact one-character link shifts reported in #5821
- `crystal tool format --check`: passed
- `bin/ameba`: 144 files inspected, 0 failures
- `crystal spec`: 167 examples, 0 failures on Crystal 1.20.3 and 1.21.0
- the current description data from the issue's example video rendered 12 correctly aligned links, including external links and chapter markers

Manual verification before submission:

- [x] I reviewed the complete two-file diff line by line.
- [x] I opened the review page generated by the patched parser from the current `jjyesTkGNT4` description data and confirmed that all 12 external links, account mentions, and chapter markers begin and end on the intended text.

I want to be awarded the bounty associated to the issue this PR is fixing.
