### PR TITLE
feat: allow setting videojs max buffer length via config.yml

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -1,6 +1,7 @@
 'use strict';
 var player_data = JSON.parse(document.getElementById('player_data').textContent);
 var video_data = JSON.parse(document.getElementById('video_data').textContent);
+const CONFIG = JSON.parse(document.getElementById('config').textContent);
 
 var options = {
     liveui: true,
@@ -53,6 +54,14 @@ videojs.Vhs.xhr.beforeRequest = function(options) {
     }
     return options;
 };
+
+// Buffer limits
+if (CONFIG.videojs.goal_buffer_length) {
+    videojs.Vhs.GOAL_BUFFER_LENGTH = CONFIG.videojs.goal_buffer_length;
+}
+if (CONFIG.videojs.max_goal_buffer_length) {
+    videojs.Vhs.MAX_GOAL_BUFFER_LENGTH = CONFIG.videojs.max_goal_buffer_length;
+}
 
 var player = videojs('player', options);
 

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -593,6 +593,27 @@ hmac_key: "CHANGE_ME!!"
 ## browser's cookies).
 ##
 
+#########################################
+#
+#  VideoJS Settings
+#
+#########################################
+
+videojs:
+  ## Change goal buffer length
+  ##
+  ## Accepted values: a positive integer OR null
+  ## Default: 30
+  ##
+  goal_buffer_length: 30
+
+  ## Change max goal buffer length
+  ##
+  ## Accepted values: a positive integer OR null
+  ## Default: 60
+  ##
+  max_goal_buffer_length: 60
+
 default_user_preferences:
 
   # -----------------------------

--- a/src/invidious/config.cr
+++ b/src/invidious/config.cr
@@ -186,6 +186,19 @@ class Config
   # Disable easy to abuse API endpoints
   property disable_abusable_api : Bool = false
 
+  property videojs : VideoJSConfig = VideoJSConfig.from_yaml("")
+
+  struct VideoJSConfig
+    include YAML::Serializable
+    include JSON::Serializable
+
+    # This are the default values that VideoJS uses.
+    # See `assets/videojs/video.js/video.js` file
+    # and search for `GOAL_BUFFER_LENGTH` and `MAX_GOAL_BUFFER_LENGTH`
+    property goal_buffer_length : Int32? = 30
+    property max_goal_buffer_length : Int32? = 60
+  end
+
   def disabled?(option)
     case disabled = CONFIG.disable_proxy
     when Bool

--- a/src/invidious/views/embed.ecr
+++ b/src/invidious/views/embed.ecr
@@ -30,6 +30,13 @@
 }.to_pretty_json
 %>
 </script>
+<script id="config" type="application/json">
+<%=
+{
+    "videojs" => CONFIG.videojs,
+}.to_pretty_json
+%>
+</script>
 
 <%= rendered "components/player" %>
 <script src="/js/embed.js?v=<%= ASSET_COMMIT %>"></script>

--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -79,6 +79,13 @@ we're going to need to do it here in order to allow for translations.
 }.to_pretty_json
 %>
 </script>
+<script id="config" type="application/json">
+<%=
+{
+    "videojs" => CONFIG.videojs,
+}.to_pretty_json
+%>
+</script>
 
 <div id="player-container" class="h-box">
     <%= rendered "components/player" %>


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

Allows people that host Invidious to set a custom buffer length when loading DASH videos via `config.yml`.

Setting those values higher, will make the player buffer more video data.

Closes https://github.com/iv-org/invidious/issues/5855