### PR TITLE
Enable the new locales translated at more than 20%

### DIFF
--- a/src/invidious/helpers/i18n.cr
+++ b/src/invidious/helpers/i18n.cr
@@ -15,7 +15,7 @@ module I18n
   #
   LOCALES_LIST = {
     "ar"      => "العربية",               # Arabic
-    "be"      => "Беларуская",          # Belarusian
+    "be"      => "Беларуская",            # Belarusian
     "bg"      => "български",             # Bulgarian
     "bn"      => "বাংলা",                 # Bengali
     "ca"      => "Català",                # Catalan
@@ -32,13 +32,13 @@ module I18n
     "fa"      => "فارسی",                 # Persian
     "fi"      => "Suomi",                 # Finnish
     "fr"      => "Français",              # French
-    "gl"      => "Galego",              # Galician
-    "gsw"     => "Schwiizerdütsch",     # Swiss German
+    "gl"      => "Galego",                # Galician
+    "gsw"     => "Schwiizerdütsch",       # Swiss German
     "he"      => "עברית",                 # Hebrew
     "hi"      => "हिन्दी",                # Hindi
     "hr"      => "Hrvatski",              # Croatian
     "hu-HU"   => "Magyar Nyelv",          # Hungarian
-    "hy"      => "Հայերեն",             # Armenian
+    "hy"      => "Հայերեն",               # Armenian
     "id"      => "Bahasa Indonesia",      # Indonesian
     "is"      => "Íslenska",              # Icelandic
     "it"      => "Italiano",              # Italian
@@ -46,7 +46,7 @@ module I18n
     "ko"      => "한국어",                   # Korean
     "lmo"     => "Lombard",               # Lombard
     "lt"      => "Lietuvių",              # Lithuanian
-    "lv"      => "Latviešu",            # Latvian
+    "lv"      => "Latviešu",              # Latvian
     "nb-NO"   => "Norsk bokmål",          # Norwegian Bokmål
     "nl"      => "Nederlands",            # Dutch
     "pl"      => "Polski",                # Polish

--- a/src/invidious/helpers/i18n.cr
+++ b/src/invidious/helpers/i18n.cr
@@ -6,15 +6,16 @@ module I18n
   #
   #  "af"      => "", # Afrikaans
   #  "az"      => "", # Azerbaijani
-  #  "be"      => "", # Belarusian
   #  "bn_BD"   => "", # Bengali (Bangladesh)
   #  "ia"      => "", # Interlingua
   #  "or"      => "", # Odia
+  #  "sgn"     => "", # Sign Language
   #  "tk"      => "", # Turkmen
-  #  "tok      => "", # Toki Pona
+  #  "tok"     => "", # Toki Pona
   #
   LOCALES_LIST = {
     "ar"      => "العربية",               # Arabic
+    "be"      => "Беларуская",          # Belarusian
     "bg"      => "български",             # Bulgarian
     "bn"      => "বাংলা",                 # Bengali
     "ca"      => "Català",                # Catalan
@@ -31,10 +32,13 @@ module I18n
     "fa"      => "فارسی",                 # Persian
     "fi"      => "Suomi",                 # Finnish
     "fr"      => "Français",              # French
+    "gl"      => "Galego",              # Galician
+    "gsw"     => "Schwiizerdütsch",     # Swiss German
     "he"      => "עברית",                 # Hebrew
     "hi"      => "हिन्दी",                # Hindi
     "hr"      => "Hrvatski",              # Croatian
     "hu-HU"   => "Magyar Nyelv",          # Hungarian
+    "hy"      => "Հայերեն",             # Armenian
     "id"      => "Bahasa Indonesia",      # Indonesian
     "is"      => "Íslenska",              # Icelandic
     "it"      => "Italiano",              # Italian
@@ -42,6 +46,7 @@ module I18n
     "ko"      => "한국어",                   # Korean
     "lmo"     => "Lombard",               # Lombard
     "lt"      => "Lietuvių",              # Lithuanian
+    "lv"      => "Latviešu",            # Latvian
     "nb-NO"   => "Norsk bokmål",          # Norwegian Bokmål
     "nl"      => "Nederlands",            # Dutch
     "pl"      => "Polski",                # Polish


### PR DESCRIPTION
## Checklist

- [X] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [ ] AI was not used to create this pull request
- [X] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

GLM-5.2 - Max

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->
OpenChamber

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

AI did the math for the percentage of 20%, and made the change.

Second commit is me asking the AI to align all the comments and it said it's now aligned on "display column 43" even if it still doesn't look like it's aligned... Not sure, not like it really matters anyway.

---

## Pull request description

Relevant to the locale PR that was merged yesterday after I remembered that this is a thing that should be done at reasonable interval.

This PR adds all the languages that are translated at more than 20% to the list of available locales.

Details (LLM written but should be correct): Added be, gl, gsw, hy, lv to LOCALES_LIST in src/invidious/helpers/i18n.cr; updated the candidate-locales comment block to remove be, add sgn, and fix the "tok typo.


