### PR TITLE
fix: link collaborative related video channels

### DIFF
--- a/spec/invidious/videos/parser_spec.cr
+++ b/spec/invidious/videos/parser_spec.cr
@@ -1,0 +1,74 @@
+require "../../parsers_helper"
+
+Spectator.describe Invidious::Videos::Parser do
+  describe ".parse_related_video" do
+    it "uses the first creator channel for a collaborative byline" do
+      related = JSON.parse(%(
+        {
+          "videoId": "BTJGr78-zyw",
+          "title": {
+            "simpleText": "Collaborative video"
+          },
+          "shortBylineText": {
+            "runs": [
+              {
+                "text": "The Diary Of A CEO and Predictive History",
+                "navigationEndpoint": {
+                  "showDialogCommand": {
+                    "panelLoadingStrategy": {
+                      "inlineContent": {
+                        "dialogViewModel": {
+                          "customContent": {
+                            "listViewModel": {
+                              "listItems": [
+                                {
+                                  "listItemViewModel": {
+                                    "rendererContext": {
+                                      "commandContext": {
+                                        "onTap": {
+                                          "innertubeCommand": {
+                                            "browseEndpoint": {
+                                              "browseId": "UCGq-a57w-aPwyi3pW7XLiHw"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "listItemViewModel": {
+                                    "rendererContext": {
+                                      "commandContext": {
+                                        "onTap": {
+                                          "innertubeCommand": {
+                                            "browseEndpoint": {
+                                              "browseId": "UC11aHtNnc5bEPLI4jf6mnYg"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ))
+
+      parsed = Invidious::Videos::Parser.parse_related_video(related).not_nil!
+
+      expect(parsed["author"].as_s).to eq("The Diary Of A CEO and Predictive History")
+      expect(parsed["ucid"].as_s).to eq("UCGq-a57w-aPwyi3pW7XLiHw")
+    end
+  end
+end

--- a/spec/invidious/yt_backend/extractors_spec.cr
+++ b/spec/invidious/yt_backend/extractors_spec.cr
@@ -1,0 +1,25 @@
+require "../../parsers_helper"
+
+Spectator.describe HelperExtractors do
+  describe ".get_browse_id" do
+    it "extracts a direct browse endpoint" do
+      container = JSON.parse(%(
+        {
+          "navigationEndpoint": {
+            "browseEndpoint": {
+              "browseId": "UCdirect"
+            }
+          }
+        }
+      ))
+
+      expect(HelperExtractors.get_browse_id(container)).to eq("UCdirect")
+    end
+
+    it "returns an empty string when no browse endpoint exists" do
+      container = JSON.parse(%({"navigationEndpoint":{"showDialogCommand":{}}}))
+
+      expect(HelperExtractors.get_browse_id(container)).to be_empty
+    end
+  end
+end

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -1141,7 +1141,29 @@ module HelperExtractors
   # Retrieves the ID required for querying the InnerTube browse endpoint.
   # Returns an empty string when it's unable to do so
   def self.get_browse_id(container)
-    return container.dig?("navigationEndpoint", "browseEndpoint", "browseId").try &.as_s || ""
+    browse_id = container.dig?("navigationEndpoint", "browseEndpoint", "browseId")
+    return browse_id.as_s if browse_id
+
+    # Collaborative bylines open a dialog instead of linking to a channel.
+    # Use the first listed creator because video items store a single channel.
+    return container.dig?(
+      "navigationEndpoint",
+      "showDialogCommand",
+      "panelLoadingStrategy",
+      "inlineContent",
+      "dialogViewModel",
+      "customContent",
+      "listViewModel",
+      "listItems",
+      0,
+      "listItemViewModel",
+      "rendererContext",
+      "commandContext",
+      "onTap",
+      "innertubeCommand",
+      "browseEndpoint",
+      "browseId"
+    ).try &.as_s || ""
   end
 end
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

- [ ] AI was not used to create this pull request
- [x] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**

OpenAI Codex (GPT-5; reasoning level not exposed by the client)

**Tool(s) used:**

OpenAI Codex in Visual Studio Code, local git, GitHub CLI, and Docker.

**How was AI used?**

---

## Pull request description

Fixes #5722

I would like to claim the bounty associated with this issue.

Collaborative related-video bylines use a `showDialogCommand` instead of a direct channel `browseEndpoint`. As a result, `get_browse_id` returned an empty string and the watch page rendered the combined author name as plain text.

This keeps the existing direct browse-ID lookup and adds a fallback to the first creator listed in the collaboration dialog. Related-video items currently store one `ucid`, so the combined author text is preserved while the link targets the first listed creator.

Regression coverage verifies the direct endpoint, missing endpoint behavior, and the full related-video parser path for a collaborative byline.

## Validation

- `crystal spec spec/invidious/yt_backend/extractors_spec.cr spec/invidious/videos/parser_spec.cr`: 3 examples, 0 failures
- `crystal spec`: 167 examples, 0 failures
- Crystal formatter check on all changed Crystal files: passed
- `bin/ameba`: 144 files inspected, 0 failures
- Strict Crystal 1.20.3 build with all warnings treated as errors: passed
- Isolated local master-versus-branch test with Invidious Companion:
  - master returned an empty `authorId` and rendered the collaborative author as plain text
  - this branch returned `authorId=UCatt7TBjfBkiJWx8khav_Gg` and linked the collaborative author to that channel
- Human review: I read the AI policy, inspected the final code and tests, manually clicked the collaborative author link on the local watch page, confirmed that it opened the correct Piers Morgan Uncensored channel, and approved submission.
