### PR TITLE
fix: pass `-no-pie` link flag argument to include debug information again for OCI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/root/.cache/crystal if [[ "${release}" == 1 ]] ; 
         PKG_CONFIG_PATH=/openssl-${OPENSSL_VERSION} \
         crystal build ./src/invidious.cr \
         --static --warnings all \
-        --link-flags "-lxml2 -llzma -no-pie";  \
+        --link-flags "-lxml2 -llzma -no-pie"; \
     fi
 
 FROM alpine:3.24

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,17 +48,29 @@ RUN crystal spec --warnings all \
 ARG OPENSSL_VERSION
 COPY --from=openssl-builder /openssl-${OPENSSL_VERSION} /openssl-${OPENSSL_VERSION}
 
+# 2026-08-04:
+#
+# `-no-pie` has been added to link flags due to missing debug information
+# when compiling Invidious using `--static` (because `--static` enables PIE, but
+# with PIE enabled, Crystal cannot provide debug information when an error
+# in Invidious appears)
+# References:
+# - https://forum.crystal-lang.org/t/gcc-15-on-alpine-linux-changes-static-to-imply-pie-i-e-static-pie/9074/5?u=fijxu
+# - https://github.com/crystal-lang/distribution-scripts/issues/445
+# - https://github.com/84codes/crystal-packages/issues/41
+#
+# `-no-pie` can be removed once it's fixed.
 RUN --mount=type=cache,target=/root/.cache/crystal if [[ "${release}" == 1 ]] ; then \
         PKG_CONFIG_PATH=/openssl-${OPENSSL_VERSION} \
         crystal build ./src/invidious.cr \
         --release \
         --static --warnings all \
-        --link-flags "-lxml2 -llzma"; \
+        --link-flags "-lxml2 -llzma -no-pie"; \
     else \
         PKG_CONFIG_PATH=/openssl-${OPENSSL_VERSION} \
         crystal build ./src/invidious.cr \
         --static --warnings all \
-        --link-flags "-lxml2 -llzma"; \
+        --link-flags "-lxml2 -llzma -no-pie";  \
     fi
 
 FROM alpine:3.24


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

`-no-pie` has been added to link flags due to missing debug information when compiling Invidious using `--static`, because `--static` enables PIE when using GCC 15 (which is included in Alpine 3.23+ OCIs), but with PIE enabled, Crystal cannot provide debug information when an error in Invidious appears.

References:
 - https://forum.crystal-lang.org/t/gcc-15-on-alpine-linux-changes-static-to-imply-pie-i-e-static-pie/9074/5?u=fijxu
 - https://github.com/crystal-lang/distribution-scripts/issues/445
 - https://github.com/84codes/crystal-packages/issues/41

`-no-pie` can be removed once it's fixed.
