### PR TITLE
feat: Use Innertube instead of channel RSS feeds to update channels

### DIFF
--- a/src/invidious/channels/about.cr
+++ b/src/invidious/channels/about.cr
@@ -19,6 +19,11 @@ record AboutChannel,
   verified : Bool,
   is_age_gated : Bool
 
+private DELETED_CHANNEL_ERROR_MESSAGES = {
+  "This channel does not exist.",
+  "This account has been terminated for a violation of YouTube's Terms of Service.",
+}
+
 def get_about_info(ucid) : AboutChannel
   begin
     # Fetch channel information from channel home page
@@ -29,7 +34,7 @@ def get_about_info(ucid) : AboutChannel
 
   if initdata.dig?("alerts", 0, "alertRenderer", "type") == "ERROR"
     error_message = initdata["alerts"][0]["alertRenderer"]["text"]["simpleText"].as_s
-    if error_message == "This channel does not exist."
+    if DELETED_CHANNEL_ERROR_MESSAGES.includes?(error_message)
       raise NotFoundException.new(error_message)
     else
       raise InfoException.new(error_message)

--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -159,32 +159,16 @@ def fetch_channel(ucid, pull_all_videos : Bool)
   LOGGER.debug("fetch_channel: #{ucid}")
   LOGGER.trace("fetch_channel: #{ucid} : pull_all_videos = #{pull_all_videos}")
 
-  namespaces = {
-    "yt"      => "http://www.youtube.com/xml/schemas/2015",
-    "media"   => "http://search.yahoo.com/mrss/",
-    "default" => "http://www.w3.org/2005/Atom",
-  }
-
-  LOGGER.trace("fetch_channel: #{ucid} : Downloading RSS feed")
-  rss = YT_POOL.client &.get("/feeds/videos.xml?channel_id=#{ucid}").body
-  LOGGER.trace("fetch_channel: #{ucid} : Parsing RSS feed")
-  rss = XML.parse(rss)
-
-  author = rss.xpath_node("//default:feed/default:title", namespaces)
-  if !author
-    raise InfoException.new("Deleted or invalid channel")
+  # Deleted channels raise a `InfoException` exception.
+  begin
+    channel = get_about_info(ucid, nil)
+  rescue ex
+    raise ex
   end
 
-  author = author.content
+  author = channel.author
 
-  # Auto-generated channels
-  # https://support.google.com/youtube/answer/2579942
-  if author.ends_with?(" - Topic") ||
-     {"Popular on YouTube", "Music", "Sports", "Gaming"}.includes? author
-    auto_generated = true
-  end
-
-  LOGGER.trace("fetch_channel: #{ucid} : author = #{author}, auto_generated = #{auto_generated}")
+  LOGGER.trace("fetch_channel: #{ucid} : author = #{author}, auto_generated = #{channel.auto_generated}")
 
   channel = InvidiousChannel.new({
     id:         ucid,
@@ -197,61 +181,32 @@ def fetch_channel(ucid, pull_all_videos : Bool)
   LOGGER.trace("fetch_channel: #{ucid} : Downloading channel videos page")
   videos, continuation = IV::Channel::Tabs.get_videos(channel)
 
-  LOGGER.trace("fetch_channel: #{ucid} : Extracting videos from channel RSS feed")
-  rss.xpath_nodes("//default:feed/default:entry", namespaces).each do |entry|
-    video_id = entry.xpath_node("yt:videoId", namespaces).not_nil!.content
-    title = entry.xpath_node("default:title", namespaces).not_nil!.content
-
-    published = Time.parse_rfc3339(
-      entry.xpath_node("default:published", namespaces).not_nil!.content
-    )
-    updated = Time.parse_rfc3339(
-      entry.xpath_node("default:updated", namespaces).not_nil!.content
-    )
-
-    author = entry.xpath_node("default:author/default:name", namespaces).not_nil!.content
-    ucid = entry.xpath_node("yt:channelId", namespaces).not_nil!.content
-
-    views = entry
-      .xpath_node("media:group/media:community/media:statistics", namespaces)
-      .try &.["views"]?.try &.to_i64? || 0_i64
-
-    channel_video = videos
-      .select(SearchVideo)
-      .select(&.id.== video_id)[0]?
-
-    length_seconds = channel_video.try &.length_seconds
-    length_seconds ||= 0
-
-    live_now = channel_video.try &.badges.live_now?
-    live_now ||= false
-
-    premiere_timestamp = channel_video.try &.premiere_timestamp
-
-    video = ChannelVideo.new({
-      id:                 video_id,
-      title:              title,
-      published:          published,
-      updated:            updated,
-      ucid:               ucid,
-      author:             author,
-      length_seconds:     length_seconds,
-      live_now:           live_now,
-      premiere_timestamp: premiere_timestamp,
-      views:              views,
+  LOGGER.trace("fetch_channel: #{ucid} : Extracting videos from channel")
+  videos.select(SearchVideo).each do |video|
+    new_video = ChannelVideo.new({
+      id:                 video.id,
+      title:              video.title,
+      published:          video.published,
+      updated:            Time.utc,
+      ucid:               video.ucid,
+      author:             video.author,
+      length_seconds:     video.length_seconds,
+      live_now:           video.badges.live_now?,
+      premiere_timestamp: video.premiere_timestamp,
+      views:              video.views,
     })
 
-    LOGGER.trace("fetch_channel: #{ucid} : video #{video_id} : Updating or inserting video")
+    LOGGER.trace("fetch_channel: #{ucid} : video #{new_video.id} : Updating or inserting video")
 
     # We don't include the 'premiere_timestamp' here because channel pages don't include them,
     # meaning the above timestamp is always null
-    was_insert = Invidious::Database::ChannelVideos.insert(video)
+    was_insert = Invidious::Database::ChannelVideos.insert(new_video)
 
     if was_insert
-      LOGGER.trace("fetch_channel: #{ucid} : video #{video_id} : Inserted, updating subscriptions")
-      NOTIFICATION_CHANNEL.send(VideoNotification.from_video(video))
+      LOGGER.trace("fetch_channel: #{ucid} : video #{new_video.id} : Inserted, updating subscriptions")
+      NOTIFICATION_CHANNEL.send(VideoNotification.from_video(new_video))
     else
-      LOGGER.trace("fetch_channel: #{ucid} : video #{video_id} : Updated")
+      LOGGER.trace("fetch_channel: #{ucid} : video #{new_video.id} : Updated")
     end
   end
 

--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -182,7 +182,7 @@ def fetch_channel(ucid, pull_all_videos : Bool)
       id:                 video.id,
       title:              video.title,
       published:          video.published,
-      updated:            video.updated,
+      updated:            Time.utc,
       ucid:               video.ucid,
       author:             video.author,
       length_seconds:     video.length_seconds,

--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -159,12 +159,7 @@ def fetch_channel(ucid, pull_all_videos : Bool)
   LOGGER.debug("fetch_channel: #{ucid}")
   LOGGER.trace("fetch_channel: #{ucid} : pull_all_videos = #{pull_all_videos}")
 
-  # Deleted channels raise a `InfoException` exception.
-  begin
-    channel = get_about_info(ucid)
-  rescue ex
-    raise ex
-  end
+  channel = get_about_info(ucid)
 
   author = channel.author
 
@@ -187,7 +182,7 @@ def fetch_channel(ucid, pull_all_videos : Bool)
       id:                 video.id,
       title:              video.title,
       published:          video.published,
-      updated:            Time.utc,
+      updated:            video.updated,
       ucid:               video.ucid,
       author:             video.author,
       length_seconds:     video.length_seconds,

--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -161,7 +161,7 @@ def fetch_channel(ucid, pull_all_videos : Bool)
 
   # Deleted channels raise a `InfoException` exception.
   begin
-    channel = get_about_info(ucid, nil)
+    channel = get_about_info(ucid)
   rescue ex
     raise ex
   end

--- a/src/invidious/channels/channels.cr
+++ b/src/invidious/channels/channels.cr
@@ -183,7 +183,7 @@ def fetch_channel(ucid, pull_all_videos : Bool)
 
   LOGGER.trace("fetch_channel: #{ucid} : Extracting videos from channel")
   videos.select(SearchVideo).each do |video|
-    new_video = ChannelVideo.new({
+    video = ChannelVideo.new({
       id:                 video.id,
       title:              video.title,
       published:          video.published,
@@ -196,17 +196,17 @@ def fetch_channel(ucid, pull_all_videos : Bool)
       views:              video.views,
     })
 
-    LOGGER.trace("fetch_channel: #{ucid} : video #{new_video.id} : Updating or inserting video")
+    LOGGER.trace("fetch_channel: #{ucid} : video #{video.id} : Updating or inserting video")
 
     # We don't include the 'premiere_timestamp' here because channel pages don't include them,
     # meaning the above timestamp is always null
-    was_insert = Invidious::Database::ChannelVideos.insert(new_video)
+    was_insert = Invidious::Database::ChannelVideos.insert(video)
 
     if was_insert
-      LOGGER.trace("fetch_channel: #{ucid} : video #{new_video.id} : Inserted, updating subscriptions")
-      NOTIFICATION_CHANNEL.send(VideoNotification.from_video(new_video))
+      LOGGER.trace("fetch_channel: #{ucid} : video #{video.id} : Inserted, updating subscriptions")
+      NOTIFICATION_CHANNEL.send(VideoNotification.from_video(video))
     else
-      LOGGER.trace("fetch_channel: #{ucid} : video #{new_video.id} : Updated")
+      LOGGER.trace("fetch_channel: #{ucid} : video #{video.id} : Updated")
     end
   end
 

--- a/src/invidious/jobs/refresh_channels_job.cr
+++ b/src/invidious/jobs/refresh_channels_job.cr
@@ -43,7 +43,7 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
               end
             rescue ex
               LOGGER.error("RefreshChannelsJob: #{id} : #{ex.message}")
-              if ex.message == "Deleted or invalid channel"
+              if ex.is_a?(InfoException)
                 Invidious::Database::Channels.update_mark_deleted(id)
               else
                 lim_fibers = 1

--- a/src/invidious/jobs/refresh_channels_job.cr
+++ b/src/invidious/jobs/refresh_channels_job.cr
@@ -43,7 +43,7 @@ class Invidious::Jobs::RefreshChannelsJob < Invidious::Jobs::BaseJob
               end
             rescue ex
               LOGGER.error("RefreshChannelsJob: #{id} : #{ex.message}")
-              if ex.is_a?(InfoException)
+              if ex.is_a?(NotFoundException)
                 Invidious::Database::Channels.update_mark_deleted(id)
               else
                 lim_fibers = 1


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

GLM-5.2

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

OpenCode

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

To quick replace variables that I set and put them directly into the `ChannelVideo.new()` call

<img height="400" alt="image" src="https://github.com/user-attachments/assets/e89e3e89-d7d8-476d-95d8-1b453d2e63f1" />

All the other logic was handled manually

---

## Pull request description

Replaces fetching the videos of channels from the channels RSS feeds with Innertube, most of the work was already done by the `get_about_info()` function which returned most of the information needed to get the videos from channels.

I tested it locally with some channels and it worked fine, it was able to get the videos from the channels.

I also tested setting `CONFIG.full_refresh` to true to pull all the videos, and it fetched all the videos without problems.

Then, to test the `RefreshChannelsJob` job with a deleted channel, I inserted a deleted channel ID (`UCkowLGphRyJEH5LR4A2Z-_g`) to the database to simulate how it would work with a deleted channel (since you can't subscribe to deleted channels, of course!):

<img height="200" alt="image" src="https://github.com/user-attachments/assets/562199bc-392f-439d-8be3-747de8dc9551" />

<img height="100" alt="image" src="https://github.com/user-attachments/assets/04b5d781-0d13-40f9-ad5c-599ded24424f" />

And the channel was marked as deleted in the database and frontend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel metadata and video retrieval for more reliable channel updates.
  * Improved detection of invalid, deleted, or terminated channels during refreshes.
  * Preserved retry backoff behavior for other refresh errors.
  * Continued saving newly discovered videos and sending notifications during channel updates.
  * Improved handling of channel information errors to distinguish unavailable channels from temporary retrieval issues.
  * Improved recognition of channels removed for terms-of-service violations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change replaces channel RSS refreshes with Innertube channel metadata and video retrieval, including continuation-based full refreshes. One feed behavior remains broken: an unchanged video receives a new Atom update time on every refresh, which can cause feed readers to reprocess or notify subscribers about old entries. The prior deleted-channel concern is disproved: the refresh job marks a channel deleted only for `NotFoundException`; other exceptions enter the backoff path.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not ready to merge until unchanged channel videos retain a stable Atom update timestamp across refreshes.

Refreshing an unchanged video persists the current refresh time and exposes it as Atom `<updated>`, making feed consumers observe a change that did not occur.

**Files Needing Attention:** src/invidious/channels/channels.cr
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and attached artifacts showing channel-video persistence and the Atom harness.
- T-Rex executed the refresh-channel transient-error branch check and validated the proof harness syntax for the first finding.
- T-Rex captured the first and second unchanged-video refresh outputs and the corresponding Atom output to support validation.
- T-Rex produced a second P1 finding proof to accompany the same finding.
- T-Rex ran the general-contract-validation-proof, documenting timestamp changes, relevant code locations, and the absence of repository modifications.

<a href="https://app.greptile.com/trex/runs/19172679/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Two-argument get_about_info invocation prevents compilation**

   - **Bug**
     - `fetch_channel` calls `get_about_info(ucid, nil)` at `src/invidious/channels/channels.cr:164`, but compilation resolves only `get_about_info(ucid) : AboutChannel` from `src/invidious/channels/about.cr:22`. `make verify` fails at that exact call with Crystal’s arity diagnostic.
   - **Cause**
     - The call site retains an obsolete second `nil` argument after the available `get_about_info` method signature became single-argument.
   - **Fix**
     - Change the call at `src/invidious/channels/channels.cr:164` to `get_about_info(ucid)` and rerun `make verify`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Channel refresh rewrites Atom entry updated time for unchanged videos**

   - **Bug**
     - `fetch_channel` constructs every discovered `ChannelVideo` with the refresh-time `updated` value; for an already stored ID, the insert conflict clause writes that value and feeds serialize it as `<updated>`, so unchanged source metadata appears freshly updated.
   - **Cause**
     - The conflict update unconditionally executes `updated = $4`, while `$4` is populated with `Time.utc` when each refreshed channel video is constructed.
   - **Fix**
     - Preserve the existing `updated` value on conflict unless a source-derived field that should advance Atom update time has actually changed, or populate `updated` from a stable upstream update timestamp.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unchanged channel-video refreshes rewrite the Atom updated timestamp**

   - **Bug**
     - Refreshing the same unchanged video twice produces a later stored `updated` timestamp, and the Atom entry exposes that later timestamp. This makes an unchanged video appear updated to Atom consumers on every channel refresh.
   - **Cause**
     - `fetch_channel` constructs each `ChannelVideo` with `updated: Time.utc` in both the initial-list and continuation-list loops. `ChannelVideos.insert` then unconditionally sets `updated = $4` on ID conflict, and `ChannelVideo#to_xml` emits `self.updated`.
   - **Fix**
     - Preserve the existing `updated` value when a conflicting video has no externally meaningful change, or derive/store `updated` from a stable upstream video-update timestamp rather than refresh time. Apply the same policy to both initial and continuation loops.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["asd"](https://github.com/iv-org/invidious/commit/6e274fb96df84eb7ebc16aa1e9dc908bd58c96d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51303524)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->