### PR TITLE
fix: link multi-creator related videos

### DIFF
--- a/spec/invidious/videos/related_videos_extract_spec.cr
+++ b/spec/invidious/videos/related_videos_extract_spec.cr
@@ -1,0 +1,101 @@
+require "../../parsers_helper.cr"
+
+Spectator.describe "parse_related_video" do
+  it "uses a directly linked channel ID" do
+    related = JSON.parse(<<-JSON)
+      {
+        "videoId": "video-id",
+        "title": {"simpleText": "Video title"},
+        "shortBylineText": {
+          "runs": [{
+            "text": "Channel name",
+            "navigationEndpoint": {
+              "browseEndpoint": {"browseId": "UC-direct"}
+            }
+          }]
+        }
+      }
+      JSON
+
+    video = Invidious::Videos::Parser.parse_related_video(related).not_nil!
+
+    expect(video["author"]).to eq("Channel name")
+    expect(video["ucid"]).to eq("UC-direct")
+  end
+
+  it "links a collaboration byline to the first listed collaborator" do
+    related = JSON.parse(<<-JSON)
+      {
+        "videoId": "collaboration-id",
+        "title": {"simpleText": "Collaboration"},
+        "shortBylineText": {
+          "runs": [{
+            "text": "First Channel and Second Channel",
+            "navigationEndpoint": {
+              "showDialogCommand": {
+                "panelLoadingStrategy": {
+                  "inlineContent": {
+                    "dialogViewModel": {
+                      "customContent": {
+                        "listViewModel": {
+                          "listItems": [
+                            {
+                              "listItemViewModel": {
+                                "rendererContext": {
+                                  "commandContext": {
+                                    "onTap": {
+                                      "innertubeCommand": {
+                                        "browseEndpoint": {"browseId": "UC-first"}
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "listItemViewModel": {
+                                "rendererContext": {
+                                  "commandContext": {
+                                    "onTap": {
+                                      "innertubeCommand": {
+                                        "browseEndpoint": {"browseId": "UC-second"}
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }]
+        }
+      }
+      JSON
+
+    video = Invidious::Videos::Parser.parse_related_video(related).not_nil!
+
+    expect(video["author"]).to eq("First Channel and Second Channel")
+    expect(video["ucid"]).to eq("UC-first")
+  end
+
+  it "keeps the channel ID empty when no destination is available" do
+    related = JSON.parse(<<-JSON)
+      {
+        "videoId": "unlinked-id",
+        "title": {"simpleText": "Unlinked video"},
+        "shortBylineText": {"runs": [{"text": "Unlinked author"}]}
+      }
+      JSON
+
+    video = Invidious::Videos::Parser.parse_related_video(related).not_nil!
+
+    expect(video["author"]).to eq("Unlinked author")
+    expect(video["ucid"]).to eq("")
+  end
+end

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -28,6 +28,18 @@ module Invidious::Videos::Parser
 
     ucid = channel_info.try { |ci| HelperExtractors.get_browse_id(ci) }
 
+    # Collaborations use a dialog command instead of linking the combined
+    # byline directly to a channel. Use the first listed collaborator as the
+    # destination while preserving YouTube's combined author label.
+    if ucid.try &.empty?
+      ucid = channel_info.try &.dig?(
+        "navigationEndpoint", "showDialogCommand", "panelLoadingStrategy",
+        "inlineContent", "dialogViewModel", "customContent", "listViewModel",
+        "listItems", 0, "listItemViewModel", "rendererContext", "commandContext",
+        "onTap", "innertubeCommand", "browseEndpoint", "browseId"
+      ).try &.as_s
+    end
+
     short_view_count = related.try do |r|
       HelperExtractors.get_short_view_count(r).to_s
     end


### PR DESCRIPTION
## Summary

- fall back to the first collaborator channel ID when a related video's combined byline opens YouTube's collaboration dialog
- preserve the combined creator label shown by YouTube
- add regression coverage for direct, collaboration, and unlinked bylines

The related-video data model currently exposes one `ucid`. YouTube orders the collaboration dialog with the primary/first creator first, so this uses that first listed collaborator as the link destination while keeping the full attribution text.

## Verification

- `crystal tool format --check`
- `crystal spec spec/invidious/videos/related_videos_extract_spec.cr spec/invidious/videos/regular_videos_extract_spec.cr spec/invidious/videos/scheduled_live_extract_spec.cr` (6 examples, 0 failures)
- `crystal build --warnings all --error-on-warnings --no-codegen --error-trace src/invidious.cr`
- Ameba on both changed files (0 failures)
- live payload from `/watch?v=IZZVijQ0gkA`: related video `dbVdnL6HWOg` resolves the combined byline to the first collaborator channel `UCatt7TBjfBkiJWx8khav_Gg`
- the collaboration regression test fails against unpatched `master` and passes with this change

Fixes: #5722

I want to be awarded the bounty associated to the issue this PR is fixing.
