### PR TITLE
Fix custom emojis in comments and descriptions

### DIFF
--- a/spec/invidious/videos/description_spec.cr
+++ b/spec/invidious/videos/description_spec.cr
@@ -121,6 +121,25 @@ Spectator.describe "parse_description" do
     )
   end
 
+  it "escapes an attachment fallback exactly once when its label is absent" do
+    description = JSON.parse(%({
+      "content":"<&",
+      "attachmentRuns":[{
+        "startIndex":0,
+        "length":2,
+        "element":{"type":{"imageType":{"image":{"sources":[{
+          "url":"https://lh3.googleusercontent.com/custom=s16",
+          "width":16,
+          "height":16
+        }]}}}}
+      }]
+    }))
+
+    expect(parse_description(description, "video-id")).to eq(
+      %(<img alt="&lt;&amp;" src="/ggpht/custom=s16" title="&lt;&amp;" width="16" height="16" class="channel-emoji" />)
+    )
+  end
+
   it "does not render zero-length graphical attachments" do
     description = JSON.parse(%({
       "content":"plain text",

--- a/spec/invidious/videos/description_spec.cr
+++ b/spec/invidious/videos/description_spec.cr
@@ -1,0 +1,123 @@
+require "json"
+require "uri"
+
+require "spectator"
+
+require "../../../src/invidious/helpers/utils"
+require "../../../src/invidious/videos/description"
+
+Spectator.describe "parse_description" do
+  it "renders custom emojis using the current YouTube attachment-run schema" do
+    description = JSON.parse(%({
+      "content":":face-red-heart-shape::face-orange-biting-nails:",
+      "attachmentRuns":[
+        {
+          "startIndex":0,
+          "length":22,
+          "element":{"type":{"imageType":{"image":{"sources":[{
+            "url":"https://lh3.googleusercontent.com/red-heart=s16-w24-h24-c-k-nd",
+            "width":16,
+            "height":16
+          }]}}}},
+          "properties":{"accessibilityProperties":{"label":"face-red-heart-shape"}}
+        },
+        {
+          "startIndex":22,
+          "length":26,
+          "element":{"type":{"imageType":{"image":{"sources":[{
+            "url":"https://lh3.googleusercontent.com/biting-nails=s16-w24-h24-c-k-nd",
+            "width":16,
+            "height":16
+          }]}}}},
+          "properties":{"accessibilityProperties":{"label":"face-orange-biting-nails"}}
+        }
+      ]
+    }))
+
+    expect(parse_description(description, "video-id")).to eq(
+      %(<img alt="face-red-heart-shape" src="/ggpht/red-heart=s16-w24-h24-c-k-nd" title="face-red-heart-shape" width="16" height="16" class="channel-emoji" />) +
+      %(<img alt="face-orange-biting-nails" src="/ggpht/biting-nails=s16-w24-h24-c-k-nd" title="face-orange-biting-nails" width="16" height="16" class="channel-emoji" />)
+    )
+  end
+
+  it "keeps command runs and UTF-16 attachment indexes aligned" do
+    description = JSON.parse(%({
+      "content":"😀visit :custom:",
+      "commandRuns":[{
+        "startIndex":2,
+        "length":5,
+        "onTap":{"innertubeCommand":{"urlEndpoint":{"url":"https://example.com"}}}
+      }],
+      "attachmentRuns":[{
+        "startIndex":8,
+        "length":8,
+        "element":{"type":{"imageType":{"image":{"sources":[{
+          "url":"https://yt3.ggpht.com/custom=s16",
+          "width":16,
+          "height":16
+        }]}}}},
+        "properties":{"accessibilityProperties":{"label":"custom"}}
+      }]
+    }))
+
+    expect(parse_description(description, "video-id")).to eq(
+      %(😀<a href="https://example.com">visit</a> <img alt="custom" src="/ggpht/custom=s16" title="custom" width="16" height="16" class="channel-emoji" />)
+    )
+  end
+
+  it "preserves the escaped shortcode when an attachment source is unsupported" do
+    description = JSON.parse(%({
+      "content":"before <:custom:> after",
+      "attachmentRuns":[{
+        "startIndex":8,
+        "length":8,
+        "element":{"type":{"imageType":{"image":{"sources":[{
+          "url":"https://example.com/custom.png",
+          "width":16,
+          "height":16
+        }]}}}},
+        "properties":{"accessibilityProperties":{"label":"custom"}}
+      }]
+    }))
+
+    expect(parse_description(description, "video-id")).to eq("before &lt;:custom:&gt; after")
+  end
+
+  it "escapes attachment labels before inserting them into HTML" do
+    description = JSON.parse(%({
+      "content":":custom:",
+      "attachmentRuns":[{
+        "startIndex":0,
+        "length":8,
+        "element":{"type":{"imageType":{"image":{"sources":[{
+          "url":"https://lh3.googleusercontent.com/custom=s16",
+          "width":16,
+          "height":16
+        }]}}}},
+        "properties":{"accessibilityProperties":{"label":"custom\\u0022 onerror=\\u0022alert(1)"}}
+      }]
+    }))
+
+    expect(parse_description(description, "video-id")).to eq(
+      %(<img alt="custom&quot; onerror=&quot;alert(1)" src="/ggpht/custom=s16" title="custom&quot; onerror=&quot;alert(1)" width="16" height="16" class="channel-emoji" />)
+    )
+  end
+
+  it "does not render zero-length graphical attachments" do
+    description = JSON.parse(%({
+      "content":"plain text",
+      "attachmentRuns":[{
+        "startIndex":0,
+        "length":0,
+        "element":{"type":{"imageType":{"image":{"sources":[{
+          "url":"https://lh3.googleusercontent.com/badge=s16",
+          "width":16,
+          "height":16
+        }]}}}},
+        "properties":{"accessibilityProperties":{"label":"badge"}}
+      }]
+    }))
+
+    expect(parse_description(description, "video-id")).to eq("plain text")
+  end
+end

--- a/spec/invidious/videos/description_spec.cr
+++ b/spec/invidious/videos/description_spec.cr
@@ -83,6 +83,24 @@ Spectator.describe "parse_description" do
     expect(parse_description(description, "video-id")).to eq("before &lt;:custom:&gt; after")
   end
 
+  it "preserves the escaped shortcode when an attachment source URL is invalid" do
+    description = JSON.parse(%({
+      "content":"before <:custom:> after",
+      "attachmentRuns":[{
+        "startIndex":8,
+        "length":8,
+        "element":{"type":{"imageType":{"image":{"sources":[{
+          "url":"https://lh3.googleusercontent.com:invalid/custom.png",
+          "width":16,
+          "height":16
+        }]}}}},
+        "properties":{"accessibilityProperties":{"label":"custom"}}
+      }]
+    }))
+
+    expect(parse_description(description, "video-id")).to eq("before &lt;:custom:&gt; after")
+  end
+
   it "escapes attachment labels before inserting them into HTML" do
     description = JSON.parse(%({
       "content":":custom:",

--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -1,3 +1,4 @@
+require "html"
 require "json"
 require "uri"
 
@@ -40,6 +41,34 @@ private def copy_string(str : String::Builder, iter : Iterator, count : Int) : I
   return copied
 end
 
+private def render_description_attachment(attachment : JSON::Any, fallback : String) : String?
+  source = attachment.dig?("element", "type", "imageType", "image", "sources", 0)
+  return if source.nil?
+
+  source_url = source["url"]?.try &.as_s?
+  return if source_url.nil?
+
+  uri = URI.parse(source_url)
+  return if uri.scheme != "https"
+
+  # Custom emoji URLs use either host; the existing /ggpht proxy serves the
+  # same request path through yt3.ggpht.com.
+  return unless {"lh3.googleusercontent.com", "yt3.ggpht.com"}.includes?(uri.host)
+
+  label = attachment.dig?("properties", "accessibilityProperties", "label").try &.as_s? || fallback
+  width = source["width"]?.try &.as_i? || 16_i64
+  height = source["height"]?.try &.as_i? || 16_i64
+
+  String.build do |str|
+    str << %(<img alt=") << HTML.escape(label) << %(" )
+    str << %(src="/ggpht) << HTML.escape(uri.request_target) << %(" )
+    str << %(title=") << HTML.escape(label) << %(" )
+    str << %(width=") << width << %(" )
+    str << %(height=") << height << %(" )
+    str << %(class="channel-emoji" />)
+  end
+end
+
 def parse_description(desc, video_id : String) : String?
   return "" if desc.nil?
 
@@ -47,7 +76,8 @@ def parse_description(desc, video_id : String) : String?
   return "" if content.empty?
 
   commands = desc["commandRuns"]?.try &.as_a
-  if commands.nil?
+  attachments = desc["attachmentRuns"]?.try &.as_a
+  if commands.nil? && attachments.nil?
     # Slightly faster than HTML.escape, as we're only doing one pass on
     # the string instead of five for the standard library
     return String.build do |str|
@@ -60,31 +90,48 @@ def parse_description(desc, video_id : String) : String?
   # (0x10000 and above) are encoded as UTF-16 surrogate pairs, which are
   # automatically decoded by the JSON parser. It means that we need to count
   # copied byte in a special manner, preventing the use of regular string copy.
+  runs = [] of NamedTuple(start: Int32, length: Int32, attachment: Bool, data: JSON::Any)
+  commands.try &.each do |command|
+    runs << {start: command["startIndex"].as_i, length: command["length"].as_i, attachment: false, data: command}
+  end
+  attachments.try &.each do |attachment|
+    runs << {start: attachment["startIndex"].as_i, length: attachment["length"].as_i, attachment: true, data: attachment}
+  end
+  runs.sort_by! { |run| {run[:start], run[:attachment] ? 0 : 1} }
+
   iter = content.each_codepoint
 
   index = 0
 
   return String.build do |str|
-    commands.each do |command|
-      cmd_start = command["startIndex"].as_i
-      cmd_length = command["length"].as_i
+    runs.each do |run|
+      run_start = run[:start]
+      run_length = run[:length]
 
-      # Copy the text chunk between this command and the previous if needed.
-      length = cmd_start - index
+      # If command and attachment runs overlap, ignore a lower-priority run
+      # once that section has already been consumed.
+      next if run_start < index
+
+      # Copy the text chunk between this run and the previous if needed.
+      length = run_start - index
       index += copy_string(str, iter, length)
 
-      # We need to copy the command's text using the iterator
-      # and the special function defined above.
-      cmd_content = String.build(cmd_length) do |str2|
-        copy_string(str2, iter, cmd_length)
+      # We need to copy the run's text using the iterator and the special
+      # function defined above.
+      run_content = String.build(run_length) do |str2|
+        copy_string(str2, iter, run_length)
       end
 
-      link = cmd_content
-      if on_tap = command.dig?("onTap", "innertubeCommand")
-        link = parse_link_endpoint(on_tap, cmd_content, video_id)
+      if run[:attachment] && run_length > 0
+        str << (render_description_attachment(run[:data], run_content) || run_content)
+      else
+        link = run_content
+        if on_tap = run[:data].dig?("onTap", "innertubeCommand")
+          link = parse_link_endpoint(on_tap, run_content, video_id)
+        end
+        str << link
       end
-      str << link
-      index += cmd_length
+      index += run_length
     end
 
     # Copy the end of the string (past the last command).

--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -59,14 +59,18 @@ private def render_description_attachment(attachment : JSON::Any, fallback : Str
   # same request path through yt3.ggpht.com.
   return unless {"lh3.googleusercontent.com", "yt3.ggpht.com"}.includes?(uri.host)
 
-  label = attachment.dig?("properties", "accessibilityProperties", "label").try &.as_s? || fallback
+  label = if raw_label = attachment.dig?("properties", "accessibilityProperties", "label").try &.as_s?
+            HTML.escape(raw_label)
+          else
+            fallback
+          end
   width = source["width"]?.try &.as_i? || 16_i64
   height = source["height"]?.try &.as_i? || 16_i64
 
   String.build do |str|
-    str << %(<img alt=") << HTML.escape(label) << %(" )
+    str << %(<img alt=") << label << %(" )
     str << %(src="/ggpht) << HTML.escape(uri.request_target) << %(" )
-    str << %(title=") << HTML.escape(label) << %(" )
+    str << %(title=") << label << %(" )
     str << %(width=") << width << %(" )
     str << %(height=") << height << %(" )
     str << %(class="channel-emoji" />)

--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -48,7 +48,11 @@ private def render_description_attachment(attachment : JSON::Any, fallback : Str
   source_url = source["url"]?.try &.as_s?
   return if source_url.nil?
 
-  uri = URI.parse(source_url)
+  uri = begin
+    URI.parse(source_url)
+  rescue URI::Error
+    return
+  end
   return if uri.scheme != "https"
 
   # Custom emoji URLs use either host; the existing /ggpht proxy serves the


### PR DESCRIPTION
Checklist

- [x] I have read the "AI Policy" (https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

AI Disclosure

<!-- Tick exactly one -->- [ ] AI was not used to create this pull request
- [x] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

Model(s) used (and thinking/reasoning level if relevant):

OpenAI "gpt-5.6-sol" (medium reasoning)

Tool(s) used:

ChatGPT Work (Codex), with local shell/apply-patch tooling and the GitHub connector

How was AI used?

AI was used to investigate the changed YouTube response shape, identify the missing "attachmentRuns" handling, implement the parser change and regression specs, run automated checks, and draft this pull request. No subagents were used.

The human contributor read and accepted the AI policy, performed the live functional test described below, accepted responsibility for the contribution, and authorized publication.

---

Pull request description

Fixes: #5888

I want to be awarded the bounty associated to the issue this PR is fixing.

YouTube now represents custom channel emoji in "attachmentRuns", while "parse_description" only processed "commandRuns". This left emoji shortcodes unrendered in the current comment entity format and in attributed video descriptions.

This change:

- processes "commandRuns" and "attachmentRuns" together in UTF-16 index order;
- renders supported custom emoji images through the existing "/ggpht" proxy;
- keeps fallback text when an attachment source is missing or unsupported;
- restricts rendered sources to HTTPS URLs on the expected Google image hosts;
- escapes generated HTML attributes;
- preserves command-link parsing and handles overlapping or zero-length runs.

Testing

Automated:
- initial full Crystal spec suite — 177 examples, 0 failures;
- focused description parser suite after review fixes — 7 examples, 0 failures;
- Crystal formatting check after review fixes;
- Ameba on both changed files after review fixes — 2 inspected, 0 failures;

Human manual test:

- built this branch from source in GitHub Codespaces;
- fetched live YouTube comments for "Gy3bmuzmWMM" through this branch's "/api/v1/comments" endpoint;
- located the exact reproduction comment "UgxVdYO3R6wrr9sLhT54AaABAg" ("@ml5684") and rendered its "contentHtml";
- confirmed that all 13 custom emoji rendered as images in the expected 3/4/2/4 sequence, with no raw shortcodes or broken images.

The standard watch page was not used for this verification because Invidious Companion could not validate a PO token from the GitHub Codespaces IP. The comments API and renderer under test worked and were manually inspected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video descriptions now render supported channel emoji image attachments inline.
  * Attachment labels and description text are safely HTML-escaped.
  * Description elements are displayed in their correct order alongside command links.

* **Bug Fixes**
  * Unsupported or invalid attachments now fall back to readable text.
  * Overlapping and zero-length attachments are handled without disrupting descriptions.
  * Improved alignment for description elements containing emoji attachments and links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds coverage for custom emoji attachments that lack an accessibility label, ensuring fallback text is escaped once before being placed in image attributes. No defects were identified.

### T-Rex validation blocked
The focused parser reproduction could not run because the required Crystal compiler/runtime tool is not installed (`crystal: not found`, exit 127). A supported Crystal installation is required to execute the prepared focused assertions.
</details>

<h3>Confidence Score: 5/5</h3>

No author-actionable issues were found in the added regression coverage.

The final review contains no confirmed defects. The focused runtime check could not execute because the Crystal compiler/runtime is unavailable, but this environment limitation does not introduce a code finding.

**Files Needing Attention:** No files require changes. `spec/invidious/videos/description_spec.cr` should be run with the focused Crystal spec once a supported Crystal toolchain is available.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before capture, the pre-change parser revision repro for the focused '\<&' attachment was attempted, but it was blocked by the missing Crystal executable and produced no runtime observations.
- After capture, the current parser repro with the assertion for alt/title equal to &lt;&amp; was attempted, but it was blocked by the same missing Crystal executable and produced no runtime observations.

<a href="https://app.greptile.com/trex/runs/17868470/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Test custom emoji fallback escaping"](https://github.com/iv-org/invidious/commit/2338e301858625d9b91cea65687dea47c8edd7bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51303516)</sub>

<!-- /greptile_comment -->