### PR TITLE
fix(comments): preserve emoji text fallback

### DIFF
--- a/spec/invidious/videos/description_spec.cr
+++ b/spec/invidious/videos/description_spec.cr
@@ -72,4 +72,28 @@ Spectator.describe "parse_description" do
 
     expect(parse_description(description, "video-id")).to eq("hello:custom-emoji:")
   end
+
+  it "preserves attachment text when the image host is unsupported" do
+    description = JSON.parse(<<-JSON)
+      {
+        "content": "one:custom-emoji:two",
+        "attachmentRuns": [{
+          "startIndex": 3,
+          "length": 14,
+          "element": {
+            "type": {
+              "imageType": {
+                "image": {
+                  "sources": [{"url": "https://example.com/custom.png", "width": 16, "height": 16}]
+                }
+              }
+            }
+          },
+          "properties": {"accessibilityProperties": {"label": "custom-emoji"}}
+        }]
+      }
+    JSON
+
+    expect(parse_description(description, "video-id")).to eq("one:custom-emoji:two")
+  end
 end

--- a/spec/invidious/videos/description_spec.cr
+++ b/spec/invidious/videos/description_spec.cr
@@ -96,4 +96,55 @@ Spectator.describe "parse_description" do
 
     expect(parse_description(description, "video-id")).to eq("one:custom-emoji:two")
   end
+
+  it "renders attachments nested in command runs" do
+    description = JSON.parse(<<-JSON)
+      {
+        "content": "abcd",
+        "commandRuns": [{
+          "startIndex": 0,
+          "length": 4,
+          "onTap": {"innertubeCommand": {"watchEndpoint": {"videoId": "linked-video"}}}
+        }],
+        "attachmentRuns": [
+          {
+            "startIndex": 0,
+            "length": 0,
+            "element": {
+              "type": {
+                "imageType": {
+                  "image": {
+                    "sources": [{"url": "https://lh3.googleusercontent.com/emoji-start=s16", "width": 16, "height": 16}]
+                  }
+                }
+              }
+            },
+            "properties": {"accessibilityProperties": {"label": "emoji-at-start"}}
+          },
+          {
+            "startIndex": 2,
+            "length": 0,
+            "element": {
+              "type": {
+                "imageType": {
+                  "image": {
+                    "sources": [{"url": "https://lh3.googleusercontent.com/emoji-inside=s16", "width": 16, "height": 16}]
+                  }
+                }
+              }
+            },
+            "properties": {"accessibilityProperties": {"label": "emoji-inside"}}
+          }
+        ]
+      }
+    JSON
+
+    expect(parse_description(description, "video-id")).to eq(
+      %(<a href="/watch?v=linked-video">) +
+      %(<img alt="emoji-at-start" src="/ggpht/emoji-start=s16" title="emoji-at-start" width="16" height="16" class="channel-emoji" />) +
+      "ab" +
+      %(<img alt="emoji-inside" src="/ggpht/emoji-inside=s16" title="emoji-inside" width="16" height="16" class="channel-emoji" />) +
+      "cd</a>"
+    )
+  end
 end

--- a/spec/invidious/videos/description_spec.cr
+++ b/spec/invidious/videos/description_spec.cr
@@ -1,0 +1,75 @@
+require "../../parsers_helper.cr"
+
+Spectator.describe "parse_description" do
+  it "renders YouTube attachment runs as images" do
+    description = JSON.parse(<<-JSON)
+      {
+        "content": ":face-red-heart-shape::face-orange-biting-nails:",
+        "attachmentRuns": [
+          {
+            "startIndex": 0,
+            "length": 22,
+            "element": {
+              "type": {
+                "imageType": {
+                  "image": {
+                    "sources": [{
+                      "url": "https://lh3.googleusercontent.com/emoji-red=s16-w24-h24-c-k-nd",
+                      "width": 16,
+                      "height": 16
+                    }]
+                  }
+                }
+              }
+            },
+            "properties": {
+              "accessibilityProperties": {"label": "face-red-heart-shape"}
+            }
+          },
+          {
+            "startIndex": 22,
+            "length": 26,
+            "element": {
+              "type": {
+                "imageType": {
+                  "image": {
+                    "sources": [{
+                      "url": "https://lh3.googleusercontent.com/emoji-orange=s16-w24-h24-c-k-nd",
+                      "width": 16,
+                      "height": 16
+                    }]
+                  }
+                }
+              }
+            },
+            "properties": {
+              "accessibilityProperties": {"label": "face-orange-biting-nails"}
+            }
+          }
+        ]
+      }
+    JSON
+
+    html = parse_description(description, "Gy3bmuzmWMM").not_nil!
+
+    expect(html).to eq(
+      %(<img alt="face-red-heart-shape" src="/ggpht/emoji-red=s16-w24-h24-c-k-nd" title="face-red-heart-shape" width="16" height="16" class="channel-emoji" />) +
+      %(<img alt="face-orange-biting-nails" src="/ggpht/emoji-orange=s16-w24-h24-c-k-nd" title="face-orange-biting-nails" width="16" height="16" class="channel-emoji" />)
+    )
+  end
+
+  it "preserves attachment text when image data is unavailable" do
+    description = JSON.parse(<<-JSON)
+      {
+        "content": "hello:custom-emoji:",
+        "attachmentRuns": [{
+          "startIndex": 5,
+          "length": 14,
+          "element": {"type": {"imageType": {"image": {}}}}
+        }]
+      }
+    JSON
+
+    expect(parse_description(description, "video-id")).to eq("hello:custom-emoji:")
+  end
+end

--- a/spec/invidious/videos/description_spec.cr
+++ b/spec/invidious/videos/description_spec.cr
@@ -147,4 +147,43 @@ Spectator.describe "parse_description" do
       "cd</a>"
     )
   end
+
+  it "assigns boundary attachments to only the following command run" do
+    description = JSON.parse(<<-JSON)
+      {
+        "content": "abcd",
+        "commandRuns": [
+          {
+            "startIndex": 0,
+            "length": 2,
+            "onTap": {"innertubeCommand": {"watchEndpoint": {"videoId": "first-video"}}}
+          },
+          {
+            "startIndex": 2,
+            "length": 2,
+            "onTap": {"innertubeCommand": {"watchEndpoint": {"videoId": "second-video"}}}
+          }
+        ],
+        "attachmentRuns": [{
+          "startIndex": 2,
+          "length": 0,
+          "element": {
+            "type": {
+              "imageType": {
+                "image": {
+                  "sources": [{"url": "https://lh3.googleusercontent.com/emoji-boundary=s16", "width": 16, "height": 16}]
+                }
+              }
+            }
+          },
+          "properties": {"accessibilityProperties": {"label": "emoji-boundary"}}
+        }]
+      }
+    JSON
+
+    expect(parse_description(description, "video-id")).to eq(
+      %(<a href="/watch?v=first-video">ab</a>) +
+      %(<a href="/watch?v=second-video"><img alt="emoji-boundary" src="/ggpht/emoji-boundary=s16" title="emoji-boundary" width="16" height="16" class="channel-emoji" />cd</a>)
+    )
+  end
 end

--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -40,6 +40,102 @@ private def copy_string(str : String::Builder, iter : Iterator, count : Int) : I
   return copied
 end
 
+private def skip_string(iter : Iterator, count : Int) : Int
+  skipped = 0
+  while skipped < count
+    cp = iter.next
+    break if cp.is_a?(Iterator::Stop)
+
+    skipped += cp > 0xFFFF ? 2 : 1
+  end
+
+  skipped
+end
+
+private def parse_attachment_run(attachment) : String?
+  image_source = attachment.dig?("element", "type", "imageType", "image", "sources", 0)
+  return if image_source.nil?
+
+  url = image_source["url"]?.try &.as_s?
+  return if url.nil?
+
+  label = attachment.dig?("properties", "accessibilityProperties", "label").try &.as_s? || ""
+  escaped_label = HTML.escape(label)
+
+  String.build do |str|
+    str << %(<img alt=") << escaped_label << %(" )
+    str << %(src="/ggpht) << HTML.escape(URI.parse(url).request_target) << %(" )
+    str << %(title=") << escaped_label << %(")
+
+    if width = image_source["width"]?.try &.as_i?
+      str << %( width=") << width << %(")
+    end
+
+    if height = image_source["height"]?.try &.as_i?
+      str << %( height=") << height << %(")
+    end
+
+    str << %( class="channel-emoji" />)
+  end
+end
+
+private def parse_description_with_attachments(content : String, commands, attachments, video_id : String) : String
+  runs = [] of Tuple(Int32, Int32, String, JSON::Any)
+
+  commands.try &.each do |command|
+    runs << {command["startIndex"].as_i, command["length"].as_i, "command", command}
+  end
+
+  attachments.each do |attachment|
+    runs << {attachment["startIndex"].as_i, attachment["length"].as_i, "attachment", attachment}
+  end
+
+  runs.sort_by! { |run| run[0] }
+
+  iter = content.each_codepoint
+  index = 0_i32
+
+  String.build do |str|
+    runs.each do |run|
+      start_index = run[0]
+      length = run[1]
+      next if start_index < index
+
+      if start_index > index
+        index += copy_string(str, iter, start_index - index)
+      end
+
+      case run[2]
+      when "command"
+        command = run[3]
+        command_content = String.build(length) do |command_str|
+          copy_string(command_str, iter, length)
+        end
+
+        link = command_content
+        if on_tap = command.dig?("onTap", "innertubeCommand")
+          link = parse_link_endpoint(on_tap, command_content, video_id)
+        end
+        str << link
+      when "attachment"
+        attachment = run[3]
+        if attachment_html = parse_attachment_run(attachment)
+          str << attachment_html
+          skip_string(iter, length)
+        else
+          copy_string(str, iter, length)
+        end
+      end
+
+      index += length
+    end
+
+    content_size = content.ascii_only? ? content.size : utf16_length(content)
+    remaining_length = content_size - index
+    copy_string(str, iter, remaining_length) if remaining_length > 0
+  end
+end
+
 def parse_description(desc, video_id : String) : String?
   return "" if desc.nil?
 
@@ -47,6 +143,10 @@ def parse_description(desc, video_id : String) : String?
   return "" if content.empty?
 
   commands = desc["commandRuns"]?.try &.as_a
+  if attachments = desc["attachmentRuns"]?.try &.as_a
+    return parse_description_with_attachments(content, commands, attachments, video_id)
+  end
+
   if commands.nil?
     # Slightly faster than HTML.escape, as we're only doing one pass on
     # the string instead of five for the standard library

--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -93,6 +93,44 @@ private def parse_attachment_run(attachment) : String?
   end
 end
 
+private def attachment_run_inside_command?(attachment, command) : Bool
+  attachment_start = attachment["startIndex"].as_i
+  attachment_end = attachment_start + attachment["length"].as_i
+  command_start = command["startIndex"].as_i
+  command_end = command_start + command["length"].as_i
+
+  attachment_start >= command_start && attachment_end <= command_end
+end
+
+private def parse_command_run(command, nested_attachments, iter, video_id : String) : String
+  command_start = command["startIndex"].as_i
+  command_length = command["length"].as_i
+
+  command_content = String.build do |command_str|
+    index = 0
+    nested_attachments.sort_by { |attachment| attachment["startIndex"].as_i }.each do |attachment|
+      relative_start = attachment["startIndex"].as_i - command_start
+      next if relative_start < index
+
+      index += copy_string(command_str, iter, relative_start - index)
+      if attachment_html = parse_attachment_run(attachment)
+        command_str << attachment_html
+        index += skip_string(iter, attachment["length"].as_i)
+      else
+        index += copy_string(command_str, iter, attachment["length"].as_i)
+      end
+    end
+
+    copy_string(command_str, iter, command_length - index) if index < command_length
+  end
+
+  link = command_content
+  if on_tap = command.dig?("onTap", "innertubeCommand")
+    link = parse_link_endpoint(on_tap, command_content, video_id)
+  end
+  link
+end
+
 private def parse_description_with_attachments(content : String, commands, attachments, video_id : String) : String
   runs = [] of Tuple(Int32, Int32, String, JSON::Any)
 
@@ -101,6 +139,8 @@ private def parse_description_with_attachments(content : String, commands, attac
   end
 
   attachments.each do |attachment|
+    next if commands.try &.any? { |command| attachment_run_inside_command?(attachment, command) }
+
     runs << {attachment["startIndex"].as_i, attachment["length"].as_i, "attachment", attachment}
   end
 
@@ -122,15 +162,10 @@ private def parse_description_with_attachments(content : String, commands, attac
       case run[2]
       when "command"
         command = run[3]
-        command_content = String.build(length) do |command_str|
-          copy_string(command_str, iter, length)
+        nested_attachments = attachments.select do |attachment|
+          attachment_run_inside_command?(attachment, command)
         end
-
-        link = command_content
-        if on_tap = command.dig?("onTap", "innertubeCommand")
-          link = parse_link_endpoint(on_tap, command_content, video_id)
-        end
-        str << link
+        str << parse_command_run(command, nested_attachments, iter, video_id)
       when "attachment"
         attachment = run[3]
         if attachment_html = parse_attachment_run(attachment)

--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -99,7 +99,9 @@ private def attachment_run_inside_command?(attachment, command) : Bool
   command_start = command["startIndex"].as_i
   command_end = command_start + command["length"].as_i
 
-  attachment_start >= command_start && attachment_end <= command_end
+  attachment_start >= command_start &&
+    attachment_start < command_end &&
+    attachment_end <= command_end
 end
 
 private def parse_command_run(command, nested_attachments, iter, video_id : String) : String

--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -52,26 +52,40 @@ private def skip_string(iter : Iterator, count : Int) : Int
   skipped
 end
 
-private def parse_attachment_run(attachment) : String?
-  image_source = attachment.dig?("element", "type", "imageType", "image", "sources", 0)
-  return if image_source.nil?
+private def image_source(url : String) : String?
+  uri = URI.parse(url)
 
-  url = image_source["url"]?.try &.as_s?
+  case uri.host
+  when "yt3.ggpht.com", "lh3.googleusercontent.com"
+    "/ggpht#{HTML.escape(uri.request_target)}"
+  end
+rescue
+  nil
+end
+
+private def parse_attachment_run(attachment) : String?
+  source = attachment.dig?("element", "type", "imageType", "image", "sources", 0)
+  return if source.nil?
+
+  url = source["url"]?.try &.as_s?
   return if url.nil?
+
+  src = image_source(url)
+  return if src.nil?
 
   label = attachment.dig?("properties", "accessibilityProperties", "label").try &.as_s? || ""
   escaped_label = HTML.escape(label)
 
   String.build do |str|
     str << %(<img alt=") << escaped_label << %(" )
-    str << %(src="/ggpht) << HTML.escape(URI.parse(url).request_target) << %(" )
+    str << %(src=") << src << %(" )
     str << %(title=") << escaped_label << %(")
 
-    if width = image_source["width"]?.try &.as_i?
+    if width = source["width"]?.try &.as_i?
       str << %( width=") << width << %(")
     end
 
-    if height = image_source["height"]?.try &.as_i?
+    if height = source["height"]?.try &.as_i?
       str << %( height=") << height << %(")
     end
 


### PR DESCRIPTION
## Summary

- Only rewrite channel-emoji image URLs for the hosts Invidious can proxy through `/ggpht`.
- Preserve the attachment's text fallback when an unsupported image host is returned.
- Render attachments nested in command runs, including equal-offset and adjacent-run boundaries, without dropping or duplicating them.
- Add regression specs covering supported images, missing/unsupported data, nested attachments, and adjacent command runs.

## Root cause

`parse_attachment_run` previously prefixed every attachment URL with `/ggpht`, which turned unsupported hosts into invalid local image paths. The first merged run parser also treated overlapping or boundary attachment runs as already consumed after a command advanced the cursor. Supported Google image hosts retain the existing behavior, while nested attachments are now rendered inside their containing command content.

## Validation

- `crystal spec spec/invidious/videos/description_spec.cr` — 5 examples, 0 failures
- `crystal tool format --check`
- `git diff --check`
- Local Invidious reproduction URL returned HTTP 200.
- Human manual UI check: the exact reproduction page was opened locally and the comments rendered normally; the user confirmed no broken comment was visible.

## AI disclosure

- AI was used to diagnose, implement, and test this change.
- Exact model: OpenAI GPT-5, via Codex desktop.
- Tools used: Codex terminal (`gh` and Crystal), local Invidious/PostgreSQL/Companion services, and the in-app browser.
- The human contributor reviewed the diff and manually tested the local UI, and accepts responsibility for the submitted code.
- The human contributor has read and accepts `AI_POLICY.md`.

Fixes #5888

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The description renderer now preserves attachment images nested inside linked text, including zero-length and non-zero attachment runs. A focused regression check confirmed that the current implementation retains both the rendered image and the linked text surrounding it.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The focused nested-attachment regression check passed against the current parser behavior.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused Crystal reproduction against the historical parser and observed an assertion failure with a rendered link to watch video, omitting the nested image.
- Executed crystal run trex-artifacts/nested-attachment-repro.cr against the current parser; it exited successfully and both zero-length and non-zero nested-attachment assertions passed, with the image rendered between the linked ab and cd text.
- Compared execution records: the historical harness exited with code 1 and showed the old behavior, while the current repro exited with code 0 and produced linked HTML containing the image between ab and cd.
- Uploaded and referenced artifacts for the nested-attachment repro, including the repro source and before/after state logs.

<a href="https://app.greptile.com/trex/runs/17880005/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(comments): handle adjacent run bound..."](https://github.com/iv-org/invidious/commit/2f1fac21f62e2e3d3029f3ff066e3acdde7155b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51334083)</sub>

<!-- /greptile_comment -->