### PR TITLE
fix(comments): render custom channel emojis in comments and descriptions

### DIFF
--- a/spec/invidious/comments_content_spec.cr
+++ b/spec/invidious/comments_content_spec.cr
@@ -1,0 +1,29 @@
+require "../spec_helper"
+
+Spectator.describe "parse_content" do
+  it "sanitizes raw run text for emoji alt attributes if accessibility label is missing" do
+    payload = JSON.parse(%({
+      "runs": [
+        {
+          "text": "<script>alert(1)</script>",
+          "emoji": {
+            "image": {
+              "thumbnails": [
+                {
+                  "url": "http://example.com/image.jpg",
+                  "width": 24,
+                  "height": 24
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }))
+
+    result = parse_content(payload)
+    expect(result).to contain("alt=\"&lt;script&gt;alert(1)&lt;/script&gt;\"")
+    expect(result).to contain("title=\"&lt;script&gt;alert(1)&lt;/script&gt;\"")
+    expect(result).to_not contain("<script>")
+  end
+end

--- a/src/invidious/comments/content.cr
+++ b/src/invidious/comments/content.cr
@@ -67,7 +67,8 @@ def content_to_comment_html(content, video_id : String? = "")
         thumbnails = emoji_image["thumbnails"]?.try &.as_a?
         if thumbnails && (emoji_thumb = thumbnails.first?) && (thumb_url = emoji_thumb["url"]?.try &.as_s?)
           raw_label = emoji_image.dig?("accessibility", "accessibilityData", "label").try &.as_s?
-          emoji_alt = raw_label ? HTML.escape(raw_label) : text
+          raw_run_text = run["text"]?.try(&.as_s?) || ""
+          emoji_alt = raw_label ? HTML.escape(raw_label) : HTML.escape(raw_run_text)
 
           text = String.build do |str|
             str << %(<img alt=") << emoji_alt << "\" "

--- a/src/invidious/comments/content.cr
+++ b/src/invidious/comments/content.cr
@@ -63,22 +63,20 @@ def content_to_comment_html(content, video_id : String? = "")
 
     # check for custom emojis
     if run["emoji"]?
-      if run["emoji"]["isCustomEmoji"]?.try &.as_bool
-        if emoji_image = run.dig?("emoji", "image")
-          emoji_alt = emoji_image.dig?("accessibility", "accessibilityData", "label").try &.as_s || text
-          emoji_thumb = emoji_image["thumbnails"][0]
-          text = String.build do |str|
-            str << %(<img alt=") << emoji_alt << "\" "
-            str << %(src="/ggpht) << URI.parse(emoji_thumb["url"].as_s).request_target << "\" "
-            str << %(title=") << emoji_alt << "\" "
-            str << %(width=") << emoji_thumb["width"] << "\" "
-            str << %(height=") << emoji_thumb["height"] << "\" "
-            str << %(class="channel-emoji" />)
-          end
-        else
-          # Hide deleted channel emoji
-          text = ""
+      if emoji_image = run.dig?("emoji", "image")
+        emoji_alt = emoji_image.dig?("accessibility", "accessibilityData", "label").try &.as_s || text
+        emoji_thumb = emoji_image["thumbnails"][0]
+        text = String.build do |str|
+          str << %(<img alt=") << emoji_alt << "\" "
+          str << %(src="/ggpht) << URI.parse(emoji_thumb["url"].as_s).request_target << "\" "
+          str << %(title=") << emoji_alt << "\" "
+          str << %(width=") << emoji_thumb["width"] << "\" "
+          str << %(height=") << emoji_thumb["height"] << "\" "
+          str << %(class="channel-emoji" />)
         end
+      else
+        # Hide deleted channel emoji
+        text = ""
       end
     end
 

--- a/src/invidious/comments/content.cr
+++ b/src/invidious/comments/content.cr
@@ -64,7 +64,7 @@ def content_to_comment_html(content, video_id : String? = "")
     # check for custom emojis
     if run["emoji"]?
       if emoji_image = run.dig?("emoji", "image")
-        emoji_alt = emoji_image.dig?("accessibility", "accessibilityData", "label").try &.as_s || text
+        emoji_alt = HTML.escape(emoji_image.dig?("accessibility", "accessibilityData", "label").try(&.as_s) || text)
         emoji_thumb = emoji_image["thumbnails"][0]
         text = String.build do |str|
           str << %(<img alt=") << emoji_alt << "\" "

--- a/src/invidious/comments/content.cr
+++ b/src/invidious/comments/content.cr
@@ -64,19 +64,27 @@ def content_to_comment_html(content, video_id : String? = "")
     # check for custom emojis
     if run["emoji"]?
       if emoji_image = run.dig?("emoji", "image")
-        emoji_alt = HTML.escape(emoji_image.dig?("accessibility", "accessibilityData", "label").try(&.as_s) || text)
-        emoji_thumb = emoji_image["thumbnails"][0]
-        text = String.build do |str|
-          str << %(<img alt=") << emoji_alt << "\" "
-          str << %(src="/ggpht) << URI.parse(emoji_thumb["url"].as_s).request_target << "\" "
-          str << %(title=") << emoji_alt << "\" "
-          str << %(width=") << emoji_thumb["width"] << "\" "
-          str << %(height=") << emoji_thumb["height"] << "\" "
-          str << %(class="channel-emoji" />)
+        thumbnails = emoji_image["thumbnails"]?.try &.as_a?
+        if thumbnails && (emoji_thumb = thumbnails.first?) && (thumb_url = emoji_thumb["url"]?.try &.as_s?)
+          raw_label = emoji_image.dig?("accessibility", "accessibilityData", "label").try &.as_s?
+          emoji_alt = raw_label ? HTML.escape(raw_label) : text
+
+          text = String.build do |str|
+            str << %(<img alt=") << emoji_alt << "\" "
+            str << %(src="/ggpht) << URI.parse(thumb_url).request_target << "\" "
+            str << %(title=") << emoji_alt << "\" "
+            if thumb_width = emoji_thumb["width"]?
+              str << %(width=") << thumb_width << "\" "
+            end
+            if thumb_height = emoji_thumb["height"]?
+              str << %(height=") << thumb_height << "\" "
+            end
+            str << %(class="channel-emoji" />)
+          end
         end
       else
         # Hide deleted channel emoji
-        text = ""
+        text = "" if text.starts_with?(':') && text.ends_with?(':')
       end
     end
 

--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -80,8 +80,34 @@ def parse_description(desc, video_id : String) : String?
       end
 
       link = cmd_content
+      
+      if command["emoji"]?
+        if emoji_image = command.dig?("emoji", "image")
+          thumbnails = emoji_image["thumbnails"]?.try &.as_a?
+          if thumbnails && (emoji_thumb = thumbnails.first?) && (thumb_url = emoji_thumb["url"]?.try &.as_s?)
+            raw_label = emoji_image.dig?("accessibility", "accessibilityData", "label").try &.as_s?
+            emoji_alt = raw_label ? HTML.escape(raw_label) : cmd_content
+
+            link = String.build do |s|
+              s << %(<img alt=") << emoji_alt << "\" "
+              s << %(src="/ggpht) << URI.parse(thumb_url).request_target << "\" "
+              s << %(title=") << emoji_alt << "\" "
+              if thumb_width = emoji_thumb["width"]?
+                s << %(width=") << thumb_width << "\" "
+              end
+              if thumb_height = emoji_thumb["height"]?
+                s << %(height=") << thumb_height << "\" "
+              end
+              s << %(class="channel-emoji" />)
+            end
+          end
+        else
+          link = "" if link.starts_with?(':') && link.ends_with?(':')
+        end
+      end
+
       if on_tap = command.dig?("onTap", "innertubeCommand")
-        link = parse_link_endpoint(on_tap, cmd_content, video_id)
+        link = parse_link_endpoint(on_tap, link, video_id)
       end
       str << link
       index += cmd_length


### PR DESCRIPTION
Closes #5888

## Checklist
- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure
- [x] AI was used to partially create this pull request

**Tool(s) used:**
Antigravity, Gemini

**How was AI used?**
Assisted in identifying the missing emoji property checks in the JSON payload and updating the Crystal templates in comments/content.cr and description.cr.

---

## Pull request description
Fixes an issue where custom channel emojis failed to render in comments and video descriptions due to recent changes in YouTube's payload structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel emoji rendering in comments and video descriptions.
  * Added support for optional image dimensions and prevented broken images when thumbnails or URLs are unavailable.
  * Hidden deleted or unavailable emoji fallback text for cleaner display.
  * Escaped accessibility labels for safer, more consistent output.
  * Improved link handling when interacting with rendered emoji and image content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change updates custom channel emoji rendering in comments and video descriptions for the current payload shape, including optional thumbnail dimensions and unavailable emoji placeholders. The rendering preserves safe image attributes for both accessibility labels and fallback text.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No accepted blocking findings remain after exercising quoted-label and missing-label emoji rendering paths.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the former quoted-label interpolation behavior, which emitted a raw image element from a malicious accessibility label.
- Executed the current comment and description renderers with quoted labels and missing-label fallback text containing markup and attribute delimiters.
- All four current rendering paths encoded the payload as HTML entities inside image attributes, with no raw attribute delimiter surviving.
- Compared legacy interpolation with current renderers, showing that the legacy approach emitted a raw image tag while the current renderers emit escaped entities inside attributes, with no raw attribute delimiter surviving.

<a href="https://app.greptile.com/trex/runs/17950635/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(comments): sanitize raw run text for..."](https://github.com/iv-org/invidious/commit/965a48c7d7bcc321d15376cd7ae0fb4dfdf4bfc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51471709)</sub>

<!-- /greptile_comment -->