### PR TITLE
Fix orphaned users when registration partially fails

### DIFF
--- a/src/invidious/database/sessions.cr
+++ b/src/invidious/database/sessions.cr
@@ -7,7 +7,7 @@ module Invidious::Database::SessionIDs
   #  Insert
   # -------------------
 
-  def insert(sid : String, email : String, handle_conflicts : Bool = false)
+  def insert(sid : String, email : String, handle_conflicts : Bool = false, *, conn : DB::Database | DB::Connection | DB::Transaction = PG_DB)
     request = <<-SQL
       INSERT INTO session_ids
       VALUES ($1, $2, now())
@@ -15,38 +15,38 @@ module Invidious::Database::SessionIDs
 
     request += " ON CONFLICT (id) DO NOTHING" if handle_conflicts
 
-    PG_DB.exec(request, sid, email)
+    conn.exec(request, sid, email)
   end
 
   # -------------------
   #  Delete
   # -------------------
 
-  def delete(*, sid : String)
+  def delete(*, sid : String, conn : DB::Database | DB::Connection | DB::Transaction = PG_DB)
     request = <<-SQL
       DELETE FROM session_ids *
       WHERE id = $1
     SQL
 
-    PG_DB.exec(request, sid)
+    conn.exec(request, sid)
   end
 
-  def delete(*, email : String)
+  def delete(*, email : String, conn : DB::Database | DB::Connection | DB::Transaction = PG_DB)
     request = <<-SQL
       DELETE FROM session_ids *
       WHERE email = $1
     SQL
 
-    PG_DB.exec(request, email)
+    conn.exec(request, email)
   end
 
-  def delete(*, sid : String, email : String)
+  def delete(*, sid : String, email : String, conn : DB::Database | DB::Connection | DB::Transaction = PG_DB)
     request = <<-SQL
       DELETE FROM session_ids *
       WHERE id = $1 AND email = $2
     SQL
 
-    PG_DB.exec(request, sid, email)
+    conn.exec(request, sid, email)
   end
 
   # -------------------

--- a/src/invidious/database/users.cr
+++ b/src/invidious/database/users.cr
@@ -7,7 +7,7 @@ module Invidious::Database::Users
   #  Insert / delete
   # -------------------
 
-  def insert(user : User, update_on_conflict : Bool = false)
+  def insert(user : User, update_on_conflict : Bool = false, *, conn : DB::Database | DB::Connection | DB::Transaction = PG_DB)
     user_array = user.to_a
     user_array[4] = user_array[4].to_json # User preferences
 
@@ -23,16 +23,16 @@ module Invidious::Database::Users
       SQL
     end
 
-    PG_DB.exec(request, args: user_array)
+    conn.exec(request, args: user_array)
   end
 
-  def delete(user : User)
+  def delete(user : User, *, conn : DB::Database | DB::Connection | DB::Transaction = PG_DB)
     request = <<-SQL
       DELETE FROM users *
       WHERE email = $1
     SQL
 
-    PG_DB.exec(request, user.email)
+    conn.exec(request, user.email)
   end
 
   # -------------------

--- a/src/invidious/routes/account.cr
+++ b/src/invidious/routes/account.cr
@@ -124,9 +124,11 @@ module Invidious::Routes::Account
     end
 
     view_name = "subscriptions_#{sha256(user.email)}"
-    Invidious::Database::Users.delete(user)
-    Invidious::Database::SessionIDs.delete(email: user.email)
-    PG_DB.exec("DROP MATERIALIZED VIEW #{view_name}")
+    PG_DB.transaction do |tx|
+      Invidious::Database::Users.delete(user, conn: tx.connection)
+      Invidious::Database::SessionIDs.delete(email: user.email, conn: tx.connection)
+      tx.connection.exec("DROP MATERIALIZED VIEW #{view_name}")
+    end
 
     env.request.cookies.each do |cookie|
       cookie.expires = Time.utc(1990, 1, 1)

--- a/src/invidious/routes/login.cr
+++ b/src/invidious/routes/login.cr
@@ -122,11 +122,13 @@ module Invidious::Routes::Login
           end
         end
 
-        Invidious::Database::Users.insert(user)
-        Invidious::Database::SessionIDs.insert(sid, email)
+        PG_DB.transaction do |tx|
+          Invidious::Database::Users.insert(user, conn: tx.connection)
+          Invidious::Database::SessionIDs.insert(sid, email, conn: tx.connection)
 
-        view_name = "subscriptions_#{sha256(user.email)}"
-        PG_DB.exec("CREATE MATERIALIZED VIEW #{view_name} AS #{MATERIALIZED_VIEW_SQL.call(user.email)}")
+          view_name = "subscriptions_#{sha256(user.email)}"
+          tx.connection.exec("CREATE MATERIALIZED VIEW #{view_name} AS #{MATERIALIZED_VIEW_SQL.call(user.email)}")
+        end
 
         if alt = CONFIG.alternative_domains.index(host)
           env.response.cookies["SID"] = Invidious::User::Cookies.sid(CONFIG.alternative_domains[alt], sid)


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**
Mixture-of-agents orchestration on the Hermes Agent runtime; primary contributing model was MiniMax-M3 (also routed through Grok-4.5 via xAI OAuth for cross-checks).

**Tool(s) used:**
Hermes Agent with the `local-git`, `docker`, `localhost-mgr`, and `gh` integrations; local Postgres + Docker Compose for the verification environment; the official `docker/Dockerfile` (`84codes/crystal:1.20.3-alpine` builder) to compile the modified binary.

**How was AI used?**
The AI agent authored the 4-file Crystal patch, built the `invidious:fix-transaction` image, ran the happy-path and forced-orphan-view regression against the local stack, and drafted this PR. The Human (`McoreD`) directed scope, owns the fork and PR account, reviewed the diff and the running service, and takes responsibility for the change per the AI Policy. The Human supervised a fresh failure-path recheck just before posting this update: see the *Verification* section for the numbers.

---

## Pull request description

### Summary

Wrap the user create and delete flows in a single Postgres transaction so a partial failure cannot leave the database in a corrupted state.

### Root cause

In `src/invidious/routes/login.cr` (around lines 125-129), the signup path executed three independent writes:

```
Invidious::Database::Users.insert(user)
Invidious::Database::SessionIDs.insert(sid, email)
PG_DB.exec("CREATE MATERIALIZED VIEW #{view_name} AS ...")
```

None of the three were inside a `PG_DB.transaction { ... }` block, so each was its own atomic commit. If the third statement failed for any reason — view name colliding with a leftover from a prior failed attempt, a postgres connection blip, container OOM-kill between statements, etc. — the `users` row and the `session_ids` row were committed while the view was missing. The account was then broken in two ways: pages that read the view (e.g. `/feed/subscriptions`) returned 500, and re-registering the same email 500'd on the view-create collision.

The symmetric bug existed in `src/invidious/routes/account.cr` (around lines 127-129): `Users.delete` + `SessionIDs.delete` + `DROP MATERIALIZED VIEW` were also un-transacted.

This is the same defect reported in #2509 (closed 2021 as "miss-configuration"; reporter's reproducer was the literal `relation "subscriptions_... already exists (PQ::PQError)` stack from these lines).

### Fix

Add an optional `conn : DB::Database | DB::Connection | DB::Transaction = PG_DB` parameter to `Users.insert`, `Users.delete`, and all four `SessionIDs` overloads. The default keeps every existing call site working unchanged.

Wrap the three statements at each call site in `PG_DB.transaction { |tx| ... }` and pass `tx.connection` through:

```crystal
# routes/login.cr
PG_DB.transaction do |tx|
  Invidious::Database::Users.insert(user, conn: tx.connection)
  Invidious::Database::SessionIDs.insert(sid, email, conn: tx.connection)

  view_name = "subscriptions_#{sha256(user.email)}"
  tx.connection.exec("CREATE MATERIALIZED VIEW #{view_name} AS #{MATERIALIZED_VIEW_SQL.call(user.email)}")
end
```

The `DB::Database | DB::Connection | DB::Transaction` union is required because `PG_DB` is a `DB::Database` (parent type in crystal-db) while `tx.connection` yields a `DB::Connection` / `DB::Transaction`. Including all three covers every legitimate call site.

### Reproduction

1. Bring up the stack (`docker compose up -d`).
2. Pre-create a view that would collide with the next registration, where `<view>` is `subscriptions_<sha256_of_email>`:
   ```sql
   CREATE MATERIALIZED VIEW <view> AS SELECT cv.* FROM channel_videos cv WHERE FALSE;
   ```
3. POST to `/login` with that email and a fresh password.
4. Inspect `users` and `session_ids` for that email.

Before this fix: 500, but `users` and `session_ids` each contain a row for the email, and the view that was supposed to be created is still missing.

After this fix: 500, both tables empty for that email, the pre-existing view untouched.

### Verification

Built `invidious:fix-transaction` from this branch using the official `docker/Dockerfile` and ran both paths on the locally supervised stack (`localhostmgr status invidious` -> running, port 3030, failures 0):

- Happy path: registered a fresh user, redirected to `/feed/subscriptions`, `users` and `session_ids` each contain one row for the email, matching materialized view present.
- Failure path (re-run just before this update): pre-created the colliding view, POSTed to `/login`, observed `HTTP 500 POST /login`, then queried the database:
  ```
  post: users=0
  post: sessions=0
  post: view_kept=1
  ```
  Zero orphan rows. Pre-existing view untouched. Rollback works.

### Files changed

- `src/invidious/database/sessions.cr` — added `conn` parameter to `insert` and three `delete` overloads.
- `src/invidious/database/users.cr` — added `conn` parameter to `insert` and `delete`.
- `src/invidious/routes/login.cr` — wrapped the create block in `PG_DB.transaction`.
- `src/invidious/routes/account.cr` — wrapped the delete block in `PG_DB.transaction`.

23 insertions, 19 deletions. No other call sites modified — the default `conn` argument preserves backward compatibility.

Closes #2509.