### PR TITLE
feat: render custom channel emoji in descriptions and comments [bc1q4hm0sn497ch8uh35xz4kduqnlja4snqqf734d5]

### DIFF
--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -40,6 +40,8 @@ private def copy_string(str : String::Builder, iter : Iterator, count : Int) : I
   return copied
 end
 
+private record Run, start_index : Int32, length : Int32, kind : Symbol, data : JSON::Any
+
 def parse_description(desc, video_id : String) : String?
   return "" if desc.nil?
 
@@ -47,47 +49,119 @@ def parse_description(desc, video_id : String) : String?
   return "" if content.empty?
 
   commands = desc["commandRuns"]?.try &.as_a
-  if commands.nil?
-    # Slightly faster than HTML.escape, as we're only doing one pass on
-    # the string instead of five for the standard library
+  attachments = desc["attachmentRuns"]?.try &.as_a
+
+  # If no runs at all, fall back to simple escape
+  if commands.nil? && attachments.nil?
     return String.build do |str|
       content_size = content.ascii_only? ? content.size : utf16_length(content)
       copy_string(str, content.each_codepoint, content_size)
     end
   end
 
-  # Not everything is stored in UTF-8 on youtube's side. The SMP codepoints
-  # (0x10000 and above) are encoded as UTF-16 surrogate pairs, which are
-  # automatically decoded by the JSON parser. It means that we need to count
-  # copied byte in a special manner, preventing the use of regular string copy.
-  iter = content.each_codepoint
+  # Merge commandRuns and attachmentRuns sorted by startIndex
+  runs = [] of Run
 
+  if commands
+    commands.each do |cmd|
+      runs << Run.new(
+        start_index: cmd["startIndex"].as_i,
+        length: cmd["length"].as_i,
+        kind: :command,
+        data: cmd
+      )
+    end
+  end
+
+  if attachments
+    attachments.each do |att|
+      runs << Run.new(
+        start_index: att["startIndex"].as_i,
+        length: att["length"].as_i,
+        kind: :attachment,
+        data: att
+      )
+    end
+  end
+
+  runs.sort_by!(&.start_index)
+
+  iter = content.each_codepoint
   index = 0
 
   return String.build do |str|
-    commands.each do |command|
-      cmd_start = command["startIndex"].as_i
-      cmd_length = command["length"].as_i
+    runs.each do |run|
+      cmd_start = run.start_index
+      cmd_length = run.length
 
-      # Copy the text chunk between this command and the previous if needed.
+      # Copy the text chunk between this run and the previous if needed.
       length = cmd_start - index
       index += copy_string(str, iter, length)
 
-      # We need to copy the command's text using the iterator
+      # We need to copy the run's text using the iterator
       # and the special function defined above.
       cmd_content = String.build(cmd_length) do |str2|
         copy_string(str2, iter, cmd_length)
       end
 
-      link = cmd_content
-      if on_tap = command.dig?("onTap", "innertubeCommand")
-        link = parse_link_endpoint(on_tap, cmd_content, video_id)
+      if run.kind == :command
+        # Handle link commands
+        link = cmd_content
+        if on_tap = run.data.dig?("onTap", "innertubeCommand")
+          link = parse_link_endpoint(on_tap, cmd_content, video_id)
+        end
+        str << link
+      elsif run.kind == :attachment
+        # Handle attachment runs (emoji images)
+        element = run.data["element"]?
+
+        if element.is_a?(JSON::Any) && element["type"]?.try &.as_s == "imageType"
+          image = element["image"]?
+
+          if image.is_a?(JSON::Any)
+            sources = image["sources"]?.try &.as_a
+
+            if sources && sources[0]?
+              source = sources[0]
+              # Get the emoji image URL
+              emoji_url = source["url"]?.try &.as_s
+              # Fallback for clientResource format (badges)
+              if emoji_url.nil? || emoji_url.empty?
+                emoji_url = source.dig?("clientResource", "imageName").try &.as_s
+              end
+
+              if emoji_url && !emoji_url.empty?
+                # Get accessibility label
+                alt_text = image.dig?("accessibility", "accessibilityData", "label").try &.as_s || cmd_content
+
+                # Build the img tag
+                if emoji_url.starts_with?("http://") || emoji_url.starts_with?("https://")
+                  str << %(<img alt=") << alt_text << "\" "
+                  str << %(src=") << emoji_url << "\" "
+                  str << %(title=") << alt_text << "\" "
+                  str << %(class="channel-emoji" />)
+                else
+                  # For internal resource names (badges), skip rendering
+                  str << cmd_content
+                end
+              else
+                str << cmd_content
+              end
+            else
+              str << cmd_content
+            end
+          else
+            str << cmd_content
+          end
+        else
+          str << cmd_content
+        end
       end
-      str << link
+
       index += cmd_length
     end
 
-    # Copy the end of the string (past the last command).
+    # Copy the end of the string (past the last run).
     content_size = content.ascii_only? ? content.size : utf16_length(content)
     remaining_length = content_size - index
     copy_string(str, iter, remaining_length) if remaining_length > 0


### PR DESCRIPTION
## Description

Fix custom channel emoji rendering which is broken in both video descriptions and comments (commentViewModel path).

### Root Cause

The parse_description function in description.cr only handled commandRuns (links) from the YouTube API response. It did not handle attachmentRuns which contain emoji image data.

The commentViewModel path (comments/youtube.cr) and the video description path (parser.cr) both route through parse_description, so emoji rendering was broken in both places.

### Fix

- Added attachmentRuns handling to parse_description
- Merges commandRuns and attachmentRuns sorted by startIndex
- Renders image-type attachments as img tags with class channel-emoji
- Falls back to client-defined resources (badges) without rendering them as images

### Testing

- Verified structure matches YouTube API attachmentRuns format for image type
- Existing emoji CSS class (channel-emoji) already defined in default.css

Fixes #5888

## BTC Bounty

This PR is submitted for the 0 BTC bounty on issue #5888.

BTC wallet: bc1q4hm0sn497ch8uh35xz4kduqnlja4snqqf734d5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video descriptions now support richer formatted content, including clickable command links and externally hosted image attachments rendered as accessible emoji.
  * Multiple description elements are displayed in their original order, with escaped text preserved between them.
* **Bug Fixes**
  * Unsupported or malformed attachments now safely fall back to their original text.
  * Internal resources are prevented from being displayed as images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds custom channel-emoji rendering for description attachment runs. Two reproduced failures need correction before merge: description emojis fetch directly from the upstream image host instead of the local image proxy, and emoji images can render at their full intrinsic dimensions because neither the markup nor stylesheet bounds them.
</details>


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

Not safe to merge until description emoji requests use the local image proxy and their rendered dimensions are bounded.

Two independent failures were reproduced with the real Crystal parser; the proxy behavior was compared with the existing comment renderer, and the layout behavior was measured in Chromium using the repository stylesheet.

**Files Needing Attention:** src/invidious/videos/description.cr needs the proxy and dimension fixes; assets/css/default.css may also need a bounded `.channel-emoji` rule if dimensions are not emitted by the renderer.
</details>


<details open><summary><h3>Security Review</h3></summary>

Description custom emojis bypass Invidious's local `/ggpht` image proxy and load from the upstream YouTube image URL. This exposes the viewer's request metadata, including their IP address and user agent, to the upstream host when viewing affected descriptions.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding about the custom emoji proxy behavior.
- T-Rex exercised the Crystal harness to validate the custom emoji proxy flow and confirmed the local ggpht proxy usage and an external HTTPS image source.
- T-Rex executed the Crystal parser fixture, captured parser output for a custom emoji attachment, and recorded media showing the large emoji rendering under two CSS rules with dimension measurements.
- T-Rex documented two additional P1 findings (proofs 2 and 4) with no artifacts provided here.

<a href="https://app.greptile.com/trex/runs/17987275/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Description custom emojis bypass the local image proxy**

   - **Bug**
     - When an `attachmentRuns` image source is an HTTPS URL, `parse_description` emits that URL directly as the image source. The focused run produced `src="https://yt3.ggpht.com/custom-emoji/party.png=s32-c-k-c0x00ffffff-no-rj"`, whereas the established custom emoji path emits `/ggpht/custom-emoji/party.png=s32-c-k-c0x00ffffff-no-rj`.
   - **Cause**
     - `src/invidious/videos/description.cr:138-142` checks that the URL is HTTP(S) but appends `emoji_url` directly rather than parsing its request target and prefixing it with `/ggpht`, as `src/invidious/comments/content.cr:71-76` does.
   - **Fix**
     - For approved external custom-emoji sources, construct the source as `/ggpht#{URI.parse(emoji_url).request_target}` (and retain safe fallback behavior for malformed or unsupported URLs), consistent with the established comment custom emoji renderer.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Description custom emojis render at unbounded intrinsic dimensions**

   - **Bug**
     - `parse_description` emits external channel-emoji `<img>` tags without explicit dimensions at `src/invidious/videos/description.cr:139-142`. The only matching CSS at `assets/css/default.css:858-860` is `margin: 0 2px`, which does not constrain size. Chromium rendered a 1200×800 intrinsic attachment at the full 1200×800 dimensions.
   - **Cause**
     - The description attachment renderer omits `width` and `height`, while `.channel-emoji` has no width, height, max-size, or object-fit declarations. In contrast, the comment custom-emoji renderer supplies width and height at `src/invidious/comments/content.cr:71-76`.
   - **Fix**
     - Use trusted thumbnail/source dimensions to emit escaped `width` and `height` attributes, or add a bounded `.channel-emoji` CSS size such as `width: 1em; height: 1em; object-fit: contain;` appropriate to the intended UI.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat: render custom channel emoji in des..."](https://github.com/iv-org/invidious/commit/bab6a7b798e18c07f6eea0afd752f546939876c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51552336)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->