### PR TITLE
Fix rendering of custom emojis

### DIFF
--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -80,40 +80,36 @@ def parse_description(desc, video_id : String) : String?
       length = cmd_start - index
       index += copy_string(str, iter, length)
 
-      if image = event.dig?("element", "type", "imageType", "image")
+      # We need to copy the command's text using the iterator
+      # and the special function defined above.
+      cmd_content = String.build(cmd_length) do |str2|
+        copy_string(str2, iter, cmd_length)
+      end
+
+      # Check if event is an attachment AND a custom emoji using regex. Format is :<name>:
+      # Members-only custom emojis have prefix :_ Built in YouTube emojis do not
+      if (image = event.dig?("element", "type", "imageType", "image")) && cmd_content.matches?(/^:[^:\s]+:$/)
+        # Source contains the emoji URL, height, and width
         source = image["sources"][0]
-        url = source["url"].as_s
 
-        # Custom emoji attachment, so far URL is lh3.googleusercontent.com and yt3.googleusercontent.com
-        # Filter out any description logo images, which use gstatic endpoint
-        if url.includes?("googleusercontent")
-          # Extract the emoji name
-          label = event.dig?("element", "properties", "accessibilityProperties", "label").try &.as_s || ""
+        # Extract the emoji name
+        label = event.dig?("element", "properties", "accessibilityProperties", "label").try &.as_s || ""
 
-          # Apply channel-emoji CSS to add margin around emoji
-          str << %(<img class="channel-emoji" alt=")
-          str << HTML.escape(label)
-          str << %(" src="/ggpht)
-          str << URI.parse(url).request_target
-          str << %(" title=")
-          str << HTML.escape(label)
-          str << %(" width=")
-          str << source["width"]?.to_s
-          str << %(" height=")
-          str << source["height"]?.to_s
-          str << %(" />)
+        # Apply channel-emoji CSS to add margin around emoji
+        str << %(<img class="channel-emoji" alt=")
+        str << HTML.escape(label)
+        str << %(" src="/ggpht)
+        str << URI.parse(url = source["url"].as_s).request_target
+        str << %(" title=")
+        str << HTML.escape(label)
+        str << %(" width=")
+        str << source["width"]?.to_s
+        str << %(" height=")
+        str << source["height"]?.to_s
+        str << %(" />)
 
-          # Use String::Builder.new to NOT append emoji text to final HTML output
-          index += copy_string(String::Builder.new, iter, cmd_length)
-        end
-
+        index += cmd_length
       else
-        # We need to copy the command's text using the iterator
-        # and the special function defined above.
-        cmd_content = String.build(cmd_length) do |str2|
-          copy_string(str2, iter, cmd_length)
-        end
-
         link = cmd_content
         if on_tap = event.dig?("onTap", "innertubeCommand")
           link = parse_link_endpoint(on_tap, cmd_content, video_id)

--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -46,8 +46,12 @@ def parse_description(desc, video_id : String) : String?
   content = desc["content"].as_s
   return "" if content.empty?
 
-  commands = desc["commandRuns"]?.try &.as_a
-  if commands.nil?
+  # attachmentRuns contains custom emoji URLs
+  attachments = desc["attachmentRuns"]?.try &.as_a || [] of JSON::Any
+
+  commands = desc["commandRuns"]?.try &.as_a || [] of JSON::Any
+
+  if commands.empty? && attachments.empty?
     # Slightly faster than HTML.escape, as we're only doing one pass on
     # the string instead of five for the standard library
     return String.build do |str|
@@ -65,28 +69,59 @@ def parse_description(desc, video_id : String) : String?
   index = 0
 
   return String.build do |str|
-    commands.each do |command|
-      cmd_start = command["startIndex"].as_i
-      cmd_length = command["length"].as_i
+    # Combine commandRuns and attachmentRuns into one array
+    events = commands + attachments
+
+    events.each do |event|
+      cmd_start = event["startIndex"].as_i
+      cmd_length = event["length"].as_i
 
       # Copy the text chunk between this command and the previous if needed.
       length = cmd_start - index
       index += copy_string(str, iter, length)
 
-      # We need to copy the command's text using the iterator
-      # and the special function defined above.
-      cmd_content = String.build(cmd_length) do |str2|
-        copy_string(str2, iter, cmd_length)
-      end
+      if image = event.dig?("element", "type", "imageType", "image")
+        source = image["sources"][0]
+        url = source["url"].as_s
 
-      link = cmd_content
-      if on_tap = command.dig?("onTap", "innertubeCommand")
-        link = parse_link_endpoint(on_tap, cmd_content, video_id)
+        # Custom emoji attachment, so far URL is lh3.googleusercontent.com and yt3.googleusercontent.com
+        # Filter out any description logo images, which use gstatic endpoint
+        if url.includes?("googleusercontent")
+          # Extract the emoji name
+          label = event.dig?("element", "properties", "accessibilityProperties", "label").try &.as_s || ""
+
+          # Apply channel-emoji CSS to add margin around emoji
+          str << %(<img class="channel-emoji" alt=")
+          str << HTML.escape(label)
+          str << %(" src="/ggpht)
+          str << URI.parse(url).request_target
+          str << %(" title=")
+          str << HTML.escape(label)
+          str << %(" width=")
+          str << source["width"]?.to_s
+          str << %(" height=")
+          str << source["height"]?.to_s
+          str << %(" />)
+
+          # Use String::Builder.new to NOT append emoji text to final HTML output
+          index += copy_string(String::Builder.new, iter, cmd_length)
+        end
+
+      else
+        # We need to copy the command's text using the iterator
+        # and the special function defined above.
+        cmd_content = String.build(cmd_length) do |str2|
+          copy_string(str2, iter, cmd_length)
+        end
+
+        link = cmd_content
+        if on_tap = event.dig?("onTap", "innertubeCommand")
+          link = parse_link_endpoint(on_tap, cmd_content, video_id)
+        end
+        str << link
+        index += cmd_length
       end
-      str << link
-      index += cmd_length
     end
-
     # Copy the end of the string (past the last command).
     content_size = content.ascii_only? ? content.size : utf16_length(content)
     remaining_length = content_size - index


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

Self hosted Gemma 4 31B, no reasoning.

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

llama.cpp, Continue vscode extension

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

Only for parsing through the codebase quickly to understand the comments pipeline. LLMs are much faster at parsing through context than I am. This saved me a lot of time.

---

## Pull request description

Closes #5888

I wanted to keep the changes minimal and keep the existing pipeline the same as much as possible, so I added an if branch. The only difference here is detection of a custom emoji. Looking through the JSON data, I couldn't find a solid identifier for if the emoji is custom or not. PR #3636 was using the key `emoji` and `isCustomEmoji`, but those are nowhere to be found in the new response. From video https://www.youtube.com/watch?v=v3wm83zoSSY

```
{"content" =>
  "LOL custom member-only emojis now work on my channel. Click the \"JOIN\" button above to be able to use these on my videos in comments:\n" +
  " :_ThioJoeAHHH:□□:_ThioJoeTurtle:□:_ThioJoeExcited::_ThioJoeWTF::_ThioJoePain::_ThioJoeStupid::_ThioJoeThonkang::_ThioJoeManyThink:□\n" +
  "\n" +
  "(Also consider leaving YouTube feedback that you like this new feature, and would also like custom emojis to work cross-channel! This can be done by clicking the menu on the left, then at the bottom go to \"send feedback\")",
 "attachmentRuns" =>
  [{"startIndex" => 135,
    "length" => 14,
    "element" =>
     {"type" =>
       {"imageType" =>
         {"image" =>
           {"sources" =>
             [{"url" =>
                "https://yt3.googleusercontent.com/6-Hzg3v1TFZI9DifzoYrJZYYTsu4quApCRT461xkMjDhaR4xUP8FbsDZe4xIdcTQi_oGPOg4=s16-w24-h24-c-k-nd",
               "width" => 16,
               "height" => 16}]},
          "playbackState" => "IMAGE_PLAYBACK_STATE_STOPPED"}},
      "properties" =>
       {"layoutProperties" =>
         {"height" => {"value" => 16, "unit" => "DIMENSION_UNIT_POINT"},
          "width" => {"value" => 16, "unit" => "DIMENSION_UNIT_POINT"},
          "margin" =>
           {"left" => {"value" => 2, "unit" => "DIMENSION_UNIT_POINT"},
            "right" => {"value" => 2, "unit" => "DIMENSION_UNIT_POINT"}}},
        "accessibilityProperties" => {"label" => "ThioJoeAHHH"}}},
    "alignment" => "ALIGNMENT_VERTICAL_CENTER"}
```
Is my understanding that YouTube made changes which caused this regression?

~The next best thing was to filter based on the URL. At least thats what I found to be working. From poking around and staring at JSON for too long, it looks like the custom emojis use 2 endpoints  `lh3.googleusercontent.com` and `yt3.googleusercontent.com` Channel emojis use the yt3, user emojis use the lh3 endpoint. I could be wrong, this is just what I noticed from observation. So if the type is an image AND the URL contains `googleusercontent`, then we can say its a custom emoji. If someone finds a better way to filter, please let me know :)~

Im filtering for custom emojis using the attachment name. For example a channel member custom emoji has the format `:_ThioJoeAHHH:` Built in YouTube custom emojis do not have the prefix `:face-red-heart-shape:`. Im using regex to detect if the string starts and ends with colon. Im assuming that a custom emoji won't have a colon or whitespace between the delimiters such as `:::` or `: :`, so those will be filtered out. I wanted to use a blacklist approach to reduce false positives in case YouTube changes the formatting in the future.

Then add the existing `channel-emoji` CSS, otherwise the custom emojis render without any margin around them. `str << %(<img class="channel-emoji" alt=")`

Another behavior I noticed(not sure if this is in scope) is the logos for social media in video description(same v=v3wm83zoSSY). From YouTube side:

<img width="132" height="63" alt="image" src="https://github.com/user-attachments/assets/ad9a3482-baff-4c17-b6d0-9401ca108fcc" />

This uses a gstatic endpoint, which we filtered out. Not sure if we need to parse these images in the future. Currently they look like this, which honestly I'm perfectly happy with:

<img width="236" height="80" alt="image" src="https://github.com/user-attachments/assets/087a5189-972c-456d-9df6-025622128f12" />


## Vid 1

Pinned comment:
https://www.youtube.com/watch?v=v3wm83zoSSY

### Before

<img width="740" height="56" alt="image" src="https://github.com/user-attachments/assets/0322cf8a-4236-4ad9-b749-7f944be48a9b" />

### After

<img width="725" height="78" alt="image" src="https://github.com/user-attachments/assets/a0d20833-7c62-4294-9563-648c63d20ac7" />

> Note: the squares are visible from YouTube side

## Vid 2

https://www.youtube.com/watch?v=Gy3bmuzmWMM&lc=UgxVdYO3R6wrr9sLhT54AaABAg

### Before

<img width="740" height="99" alt="image" src="https://github.com/user-attachments/assets/311999e2-9ef0-4f0d-8e21-167d76a9b2dc" />

Scroll down:
<img width="817" height="630" alt="image" src="https://github.com/user-attachments/assets/43bb0331-a9b9-4983-a171-26c3f349b31b" />

### After

<img width="278" height="52" alt="image" src="https://github.com/user-attachments/assets/cd862d9b-7bf6-41fe-8529-d264d0b3cd74" />

<img width="805" height="461" alt="image" src="https://github.com/user-attachments/assets/1bef8a3a-0033-4a80-9329-b003d07fcbf8" />

Yours truly,
Microslop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video descriptions now support inline image attachments from supported sources.
  * Attached images are displayed with appropriate labels, dimensions, and optimized loading.
* **Bug Fixes**
  * Improved description parsing when image attachments and other interactive content appear together.
  * Preserved existing text extraction and link handling for non-image content.
  * Plain-text descriptions continue to display correctly when no interactive elements are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Custom emoji rendering can lose an emoji when its attachment appears before a command or link in the same description. Ordering all description runs by their source position before rendering fixes the issue.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Descriptions containing an emoji attachment before a command do not preserve the channel's authored content.

One verified non-security functional failure remains in description rendering.

**Files Needing Attention:** src/invidious/videos/description.cr
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding, providing a basis for the reviewer to inspect the finding details.
- The work includes a Temporary Crystal parser harness and logs that show how the parent parser behaved before the change and how the current parser behaves after the change.
- General contract validation confirms the observed effects by comparing the harness usage and the before/after parser logs, validating the post-change behavior.
- The artifacts provide concrete evidence for reviewers to inspect the harness and the before/after parser runs.

<a href="https://app.greptile.com/trex/runs/18436641/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Description attachments are emitted after later command runs**

   - **Bug**
     - When an attachment/custom emoji precedes a command by `startIndex`, line 73 appends `attachments` after every command. The parser therefore advances its shared iterator through the later command before rendering the earlier attachment. In the executed UTF-16 repro, the custom emoji at `[0,2)` is emitted as raw text before `LINK[@go]`, and its image is appended only afterward.
   - **Cause**
     - `events = commands + attachments` preserves array-group order rather than ordering heterogeneous events by `startIndex`; the iterator and `index` are stateful across the subsequent loop.
   - **Fix**
     - Build one event list ordered ascending by `event["startIndex"].as_i` before iterating, with a deterministic tie-breaker if equal positions are valid, and add this attachment-before-command regression case.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Attachment preceding a command is dropped when runs are combined without range ordering**

   - **Bug**
     - `events = commands + attachments` processes every command before every attachment. With `:smile: LINK`, an attachment range `[0,7]`, and a command range `[8,4]`, the current parser first consumes `LINK`; when it reaches the attachment, `cmd_start - index` is negative, `copy_string` consumes no source, and `cmd_content` is empty. The emoji fails the custom-emoji regex and is never emitted. Observed current output is `:smile: <a data-harness-link="video-123">LINK</a>`—the source placeholder remains and the emoji image is lost. The parent output instead contained the link plus a trailing emoji image, which also demonstrates the underlying unsorted-order issue.
   - **Cause**
     - Lines 72-75 concatenate independently ordered arrays rather than sorting all events by `startIndex`; lines 79-87 then assume each successive event starts at or after the already-consumed index.
   - **Fix**
     - Combine the runs and sort by `startIndex` before iterating (with a deterministic tie-breaker if overlapping ranges are possible). Add a parser spec for an attachment that precedes a command run.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["filter using regex instead of hostname"](https://github.com/iv-org/invidious/commit/7ea63a320ff1fb8256df3b2479b123ef72fa7f8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52102373)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->