### PR TITLE
fix(parser): parse published date and view count for collab videos

### DIFF
--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -661,13 +661,24 @@ private module Parsers
 
         metadata = item_contents.dig("metadata", "lockupMetadataViewModel")
         title = metadata.dig("title", "content").as_s
-        # Contains the views of the video and the published time of the video.
-        metadata_parts = metadata.dig("metadata", "contentMetadataViewModel", "metadataRows", 0, "metadataParts").try &.as_a
+        view_count_text = nil
+        published = nil
 
-        view_count_text = metadata_parts.try &.find { |item| item["icon"]?.nil? && item.dig?("text", "content").try &.as_s.includes?("views") }
-          .try &.dig("text", "content").as_s
-        published = metadata_parts.try &.find { |item| item["icon"]?.nil? && item.dig?("text", "content").try &.as_s.includes?("ago") }
-          .try { |item| decode_date(item.dig("text", "content").as_s) } || Time.local
+        # Contains the views of the video and the published time of the video.
+        # Collaboration videos have multiple authors in the first row, so we check all rows.
+        if metadata_rows = metadata.dig?("metadata", "contentMetadataViewModel", "metadataRows").try &.as_a
+          metadata_rows.each do |row|
+            row.dig?("metadataParts").try &.as_a.each do |item|
+              next if item["icon"]?
+              if text = item.dig?("text", "content").try &.as_s
+                view_count_text ||= text if text.includes?("views")
+                published ||= decode_date(text) if text.includes?("ago")
+              end
+            end
+          end
+        end
+
+        published ||= Time.local
 
         view_count = short_text_to_number(view_count_text || "0")
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**

Gemini 1.5 Pro

**Tool(s) used:**

OpenCodex

**How was AI used?**

AI identified the bug in parser where collaboration videos have multiple authors, extracted all metadataRows, formatted the patch. Human reviewed.

---

## Pull request description

Fixes: #5740
Closes: #5740

I want to be awarded the bounty associated to the issue this PR is fixing.

This PR addresses the bug in channel pages for collaborative videos. Previously, the parser only checked the first `metadataRows` element `0` to extract `views` and `ago`. However, for collaborative videos, the author list might take up the first row, pushing the published date and views to the second row. By iterating over all rows, we ensure the date and view count are correctly extracted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video metadata extraction for view counts and publication dates.
  * Metadata is now detected across all available rows, including videos with varied layouts.
  * Added a local-time fallback when no publication date is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change updates collaborative video metadata parsing to search every metadata row for non-icon view-count and publication-date values. The concern that later-row metadata could be missed was disproved by exercising a lockup with collaborator data in the first row, misleading icon-bearing values in a later row, and the actual view/date values in a subsequent row: the parser returned `1,200,000` views and the expected publication instant.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge based on the exercised collaborative-video metadata path.

The public parser path was executed against a multi-row lockup fixture and correctly ignored icon-bearing metadata while extracting the later non-icon view count and publication date.

**Files Needing Attention:** No additional files need attention; `src/invidious/yt_backend/extractors.cr` was exercised directly.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I executed crystal run tmp\_lockup\_metadata\_rows\_check.cr from /home/user/repo and exercised the public parser flow: parse\_item → RichItemRendererParser → LockupViewModelParser.
- The fixture placed collaborator information in row 0, an icon-bearing 999 views and 99 years ago in row 1, and 1.2M views plus 3 weeks ago in row 2.
- The command exited with code 0 and reported views=1200000 (expected 1200000; ignored icon-bearing 999 views); the publication instant matched 3 weeks ago while ignoring the 99 years ago date.
- A second run of the same command from /home/user/repo produced identical results, with views=1200000 (expected 1200000; ignored 999 views) and the 3 weeks ago instant; the run also exited with code 0.
- Together, these results validate that the updated parser handles the multi-row collaboration layout as intended.

<a href="https://app.greptile.com/trex/runs/18306536/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(parser): parse published date and vi..."](https://github.com/iv-org/invidious/commit/d7824af24770acf87da5e6f57077fc5a8ea36a38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52208293)</sub>

<!-- /greptile_comment -->