### PR TITLE
feat(ui): link hashtags in video titles to search

### DIFF
--- a/src/invidious/views/watch.ecr
+++ b/src/invidious/views/watch.ecr
@@ -93,7 +93,7 @@ we're going to need to do it here in order to allow for translations.
 
 <div class="h-box">
     <h1>
-        <%= title %>
+        <%= title.gsub(/\B#[\p{L}\p{N}_]+/) { |hashtag| "<a href=\"/search?q=#{URI.encode_www_form(hashtag, space_to_plus: false)}\">#{hashtag}</a>" } %>
         <% if params.listen %>
             <a title="<%=I18n.translate(locale, "Video mode")%>" id="link-iv-listen" data-base-url="/watch?<%= env.params.query %>&listen=0" href="/watch?<%= env.params.query %>&listen=0">
                 <i class="icon ion-ios-videocam"></i>


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**

Gemini 1.5 Pro

**Tool(s) used:**

OpenCodex

**How was AI used?**

AI helped locate the `watch.ecr` template and formulate the regex to wrap hashtags in search links for video titles, matching YouTube's native behavior. I manually reviewed and tested the regex.

---

## Pull request description

Fixes: #442

I want to be awarded the bounty associated to the issue this PR is fixing.

This PR adds the ability to click on hashtags within video titles on the watch page. Clicking a hashtag redirects the user to the Invidious search page with the corresponding `search_query=%23<HASHTAG>` encoded, mirroring YouTube's native behavior.

**Changes:**
- The `title` string is processed through a `gsub` regex (`\B#[\p{L}\p{N}_]+`) after being HTML-escaped.
- Matches are replaced with standard HTML `<a>` tags pointing to the `/search` endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hashtags in video titles are now clickable links that open search results for the selected hashtag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change makes recognized hashtags in watch-page video titles link to search results. A reproduced rendering issue remains: literal character-reference-like text in a title can be split so its numeric portion becomes an unintended clickable hashtag link.

The watch-title linkification should preserve literal entity-like text before this change is merged.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge until watch-title linkification no longer turns literal entity-like text into hashtag links.

The failure was directly reproduced using the same escaping, regular expression, and link construction as the watch template.

**Files Needing Attention:** src/invidious/views/watch.ecr
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated contract behavior for numeric entity handling: escaping '&#65;' yields &amp;#65;, and applying the line-96 transform renders a fragment where #65 becomes a clickable link.
- T-Rex produced a proof for the posted P2 finding and prepared the review context.
- T-Rex produced a proof for the posted P1 finding and prepared the review context.

<a href="https://app.greptile.com/trex/runs/18318150/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Escaped numeric entity suffix in watch title is incorrectly linkified as a hashtag**

   - **Bug**
     - At `src/invidious/views/watch.ecr:96`, an already HTML-escaped title containing literal `&#65;` is transformed into `&amp;<a href="/search?q=%2365">#65</a>;`. The browser therefore exposes `#65` as a clickable hashtag-search link even though it originated as part of author-supplied literal entity text.
   - **Cause**
     - `title` is assigned `HTML.escape(video.title)` at line 2 before line 96 applies `/\B#[\p{L}\p{N}_]+/`. In the escaped entity `&amp;#65;`, the regex matches `#65` after `amp;` and injects an anchor into the entity representation.
   - **Fix**
     - Apply hashtag matching to the unescaped title text while escaping non-link text and the generated URL/link text safely, or otherwise exclude HTML entity syntax from hashtag matching. Do not run the hashtag regex over an already HTML-escaped string.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(ui): link hashtags in video titles ..."](https://github.com/iv-org/invidious/commit/745a4b659bdda3f5f04c674f3b4ea9133deb7065) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52234171)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->