### PR TITLE
Fix missing channel links for multi-creator related videos

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -19,14 +19,22 @@ module Invidious::Videos::Parser
       decode_length_seconds(box.as_s).to_s
     end
 
-    # Both have "short", so the "long" option shouldn't be required
-    channel_info = (related["shortBylineText"]? || related["longBylineText"]?)
-      .try &.dig?("runs", 0)
+    byline = related["shortBylineText"]? || related["longBylineText"]?
 
-    author = channel_info.try &.dig?("text")
+    author = extract_text(byline)
     author_verified = has_verified_badge?(related["ownerBadges"]?).to_s
 
-    ucid = channel_info.try { |ci| HelperExtractors.get_browse_id(ci) }
+    ucid = nil
+    runs = byline.try &.dig?("runs")
+    if runs && runs.as_a?
+      runs.as_a.each do |run|
+        id = HelperExtractors.get_browse_id(run)
+        if id && !id.to_s.empty?
+          ucid = id
+          break
+        end
+      end
+    end
 
     short_view_count = related.try do |r|
       HelperExtractors.get_short_view_count(r).to_s


### PR DESCRIPTION
Fixes #5722

When a recommended video has multiple creators, YouTube provides them as multiple runs in `shortBylineText` (e.g. `[{"text": "Creator 1", "navigationEndpoint": ...}, {"text": " and "}, {"text": "Creator 2", "navigationEndpoint": ...}]`). 
The previous parsing logic only extracted the first run (`runs[0]`), which caused missing authors or missing hyperlinks if the first run didn't contain the endpoint. 

This PR extracts the full combined author text using `extract_text`, and iterates through the runs to find the first available channel ID (`browseId`) so the hyperlink works correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved related video details by correctly identifying the creator across different byline formats.
  * Related videos now reliably display channel information when multiple byline entries are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change combines multi-creator byline text and selects the first available channel browse ID across byline runs. The related-video parser now fails Crystal compilation because the returned author value is no longer consistently represented as `JSON::Any`; the application cannot be built or deployed until that value is wrapped.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge: the changed parser prevents the application from compiling.

The compilation failure was reproduced by comparing the parent revision and this revision with the repository's verification command. The parent compiled successfully, while this revision produced the parser return-type error.

**Files Needing Attention:** src/invidious/videos/parser.cr needs the returned `author` value converted to `JSON::Any`.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and performed a Crystal type-check comparison between the parent and the PR.
- T-Rex produced a second proof for another posted P1 finding.
- T-Rex validated the contract-level implications of the PR, describing how the author field type changes affect the parse\_related\_video function and the resulting JSON structure.

<a href="https://app.greptile.com/trex/runs/18329978/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/invidious/videos/parser.cr`, line 57 ([link](https://github.com/iv-org/invidious/blob/6ecbbd2b6a2a01d93c7016c6c4433284e9a35e18/src/invidious/videos/parser.cr#L57)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Related-video parser returns the wrong hash type**

   `author` is now a `String?` from `extract_text(byline)`, while this method promises `Hash(String, JSON::Any)?`. The `author || JSON::Any.new("")` expression makes Crystal infer `Hash(String, JSON::Any | String)`, so the project no longer compiles. Wrap the author value in `JSON::Any`, such as `JSON::Any.new(author || "")`, so every returned map value matches the declared type.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Commands for the parent and PR Crystal type-check comparison](https://app.greptile.com/trex/artifacts/59385fc2-7940-4e20-93be-eca4e2527255)**

   - Lists the exact detached-worktree and \`make verify\` commands executed without changing repository source files; it documents the reproducible comparison.

   **[Parent revision compiler check succeeds](https://app.greptile.com/trex/artifacts/98725a9a-e437-430e-a203-a2ecbcfe8451)**

   - Captured \`make verify\` output for parent revision 8fde720f, which completed semantic compilation with exit code 0; the pre-PR baseline compiles.

   **[PR revision compiler check fails on parse\_related\_video return type](https://app.greptile.com/trex/artifacts/c085ab20-504f-4bb2-8da3-1f2ccdc9f93c)**

   - Captured \`make verify\` output for PR revision 6ecbbd2b, ending in the exact Hash(String, JSON::Any | String) return-type error at parser.cr line 12; the PR does not compile.

   <a href="https://app.greptile.com/trex/runs/18329978/artifacts?artifact=59385fc2-7940-4e20-93be-eca4e2527255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **PR 5924 prevents Invidious from compiling**

   - **Bug**
     - `make verify` fails on the PR revision with: `method Invidious::Videos::Parser.parse_related_video must return (Hash(String, JSON::Any) | Nil) but it is returning (Hash(String, JSON::Any | String) | Nil)`. A build/deployment of this revision cannot complete.
   - **Cause**
     - `extract_text(byline)` returns `String?`, and the returned hash at `src/invidious/videos/parser.cr:57` uses `author || JSON::Any.new("")`. Crystal therefore infers the author value as `String | JSON::Any`, incompatible with the declared `Hash(String, JSON::Any)?` at line 12.
   - **Fix**
     - Wrap the non-nil author string in `JSON::Any`, for example `"author" => JSON::Any.new(author || "")`, so every returned map value is `JSON::Any`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Fix missing channel links for multi-crea..."](https://github.com/iv-org/invidious/commit/6ecbbd2b6a2a01d93c7016c6c4433284e9a35e18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52256069)</sub>

<!-- /greptile_comment -->