### PR TITLE
Fix spamming videoplayback requests when companion is unreachable

### DIFF
--- a/src/invidious/routes/companion.cr
+++ b/src/invidious/routes/companion.cr
@@ -9,7 +9,7 @@ module Invidious::Routes::Companion
     begin
       COMPANION_POOL.client do |wrapper|
         wrapper.client.get(url, env.request.headers) do |resp|
-          return self.proxy_companion(env, resp)
+          return self.proxy_companion(env, resp, wrapper)
         end
       end
     rescue ex
@@ -29,7 +29,7 @@ module Invidious::Routes::Companion
     begin
       COMPANION_POOL.client do |wrapper|
         wrapper.client.post(url, env.request.headers, env.request.body) do |resp|
-          return self.proxy_companion(env, resp)
+          return self.proxy_companion(env, resp, wrapper)
         end
       end
     rescue ex
@@ -48,7 +48,7 @@ module Invidious::Routes::Companion
     begin
       COMPANION_POOL.client do |wrapper|
         wrapper.client.options(url, env.request.headers) do |resp|
-          return self.proxy_companion(env, resp)
+          return self.proxy_companion(env, resp, wrapper)
         end
       end
     rescue ex
@@ -58,7 +58,7 @@ module Invidious::Routes::Companion
     end
   end
 
-  private def self.proxy_companion(env, response)
+  private def self.proxy_companion(env, response, wrapper)
     env.response.status_code = response.status_code
     response.headers.each do |key, value|
       env.response.headers[key] = value
@@ -68,6 +68,7 @@ module Invidious::Routes::Companion
       return IO.copy response.body_io, env.response
     rescue ex
       LOGGER.warn("Companion response stream failed: #{ex.class}")
+      wrapper.close
       env.response.close unless env.response.closed?
       return
     end

--- a/src/invidious/routes/companion.cr
+++ b/src/invidious/routes/companion.cr
@@ -13,6 +13,8 @@ module Invidious::Routes::Companion
         end
       end
     rescue ex
+      env.response.status_code = 502
+      return env.response.print("502 Bad Gateway")
     end
   end
 
@@ -30,6 +32,8 @@ module Invidious::Routes::Companion
         end
       end
     rescue ex
+      env.response.status_code = 502
+      return env.response.print("502 Bad Gateway")
     end
   end
 
@@ -46,6 +50,8 @@ module Invidious::Routes::Companion
         end
       end
     rescue ex
+      env.response.status_code = 502
+      return env.response.print("502 Bad Gateway")
     end
   end
 

--- a/src/invidious/routes/companion.cr
+++ b/src/invidious/routes/companion.cr
@@ -13,6 +13,7 @@ module Invidious::Routes::Companion
         end
       end
     rescue ex
+      LOGGER.warn("Companion GET upstream request failed: #{ex.class}")
       env.response.status_code = 502
       return env.response.print("502 Bad Gateway")
     end
@@ -32,6 +33,7 @@ module Invidious::Routes::Companion
         end
       end
     rescue ex
+      LOGGER.warn("Companion POST upstream request failed: #{ex.class}")
       env.response.status_code = 502
       return env.response.print("502 Bad Gateway")
     end
@@ -50,6 +52,7 @@ module Invidious::Routes::Companion
         end
       end
     rescue ex
+      LOGGER.warn("Companion OPTIONS upstream request failed: #{ex.class}")
       env.response.status_code = 502
       return env.response.print("502 Bad Gateway")
     end
@@ -61,6 +64,12 @@ module Invidious::Routes::Companion
       env.response.headers[key] = value
     end
 
-    return IO.copy response.body_io, env.response
+    begin
+      return IO.copy response.body_io, env.response
+    rescue ex
+      LOGGER.warn("Companion response stream failed: #{ex.class}")
+      env.response.close unless env.response.closed?
+      return
+    end
   end
 end


### PR DESCRIPTION
Fixes #5769

Currently, if the companion proxy is enabled but unreachable, the `rescue ex` blocks in `src/invidious/routes/companion.cr` swallow the exception and return an empty HTTP 200 OK response. This causes the video player (VideoJS) to continuously spam `/companion/videoplayback` requests since it interprets the 200 OK as a valid response but receives no video data.

This PR sets `env.response.status_code = 502` (Bad Gateway) and returns an explicit error message when the companion is unreachable, preventing the player from spamming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Companion service endpoints now return a clear HTTP 502 “Bad Gateway” response when an upstream request fails.
  * Improved handling of interrupted responses to prevent connection errors from being exposed to clients.
  * Connections and responses are now closed appropriately when streaming encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Companion proxy failures now produce a single `502 Bad Gateway` response for GET, POST, and OPTIONS requests. The previously reported broken-client reuse issue was disproved: an injected response-stream failure closes the checked-out wrapper before release, so it cannot be reused.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

Focused execution confirmed that upstream request failures return one valid Bad Gateway response and that response-stream failures close the companion wrapper before it is released.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused Crystal companion failure harness against the parent revision and the current revision with an injected IO::Error, and observed that the parent wrapper remained open while the current revision closed its wrapper before release, closed the downstream response, and produced zero fallback writes.
- Injected upstream request failures through the current GET, POST, and OPTIONS handlers; each returned status 502, produced exactly one write, and the body was 502 Bad Gateway.
- Compared the parent and current revisions, confirming that the wrapper changed from open to closed on release and that the current upstream-run produced 502 responses with one write and a 502 Bad Gateway body.

<a href="https://app.greptile.com/trex/runs/18344862/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["Invalidate companion client after stream..."](https://github.com/iv-org/invidious/commit/cbb27b0f346cf0765b15a13bbacd9745abd3dce1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52259980)</sub>

<!-- /greptile_comment -->