### PR TITLE
Fix missing author_thumbnail and premiere_timestamp for SearchVideo on channel routes

### DIFF
--- a/src/invidious/channels/videos.cr
+++ b/src/invidious/channels/videos.cr
@@ -22,7 +22,6 @@ module Invidious::Channel::Tabs
   def get_videos(channel : InvidiousChannel, *, continuation : String? = nil, sort_by = "newest")
     return get_videos(
       channel.author, channel.id,
-      author_thumbnail: channel.author_thumbnail,
       continuation: continuation, sort_by: sort_by
     )
   end

--- a/src/invidious/channels/videos.cr
+++ b/src/invidious/channels/videos.cr
@@ -11,6 +11,7 @@ module Invidious::Channel::Tabs
   def get_videos(channel : AboutChannel, *, continuation : String? = nil, sort_by = "newest")
     return get_videos(
       channel.author, channel.ucid,
+      author_thumbnail: channel.author_thumbnail,
       continuation: continuation, sort_by: sort_by
     )
   end
@@ -21,15 +22,16 @@ module Invidious::Channel::Tabs
   def get_videos(channel : InvidiousChannel, *, continuation : String? = nil, sort_by = "newest")
     return get_videos(
       channel.author, channel.id,
+      author_thumbnail: channel.author_thumbnail,
       continuation: continuation, sort_by: sort_by
     )
   end
 
-  def get_videos(author : String, ucid : String, *, continuation : String? = nil, sort_by = "newest")
+  def get_videos(author : String, ucid : String, *, continuation : String? = nil, sort_by = "newest", author_thumbnail : String? = nil)
     continuation ||= make_initial_videos_ctoken(ucid, sort_by)
     initial_data = YoutubeAPI.browse(continuation: continuation)
 
-    return extract_items(initial_data, author, ucid)
+    return extract_items(initial_data, author, ucid, author_thumbnail)
   end
 
   def get_60_videos(channel : AboutChannel, *, continuation : String? = nil, sort_by = "newest")
@@ -59,7 +61,7 @@ module Invidious::Channel::Tabs
     continuation ||= make_initial_shorts_ctoken(channel.ucid, sort_by)
     initial_data = YoutubeAPI.browse(continuation: continuation)
 
-    return extract_items(initial_data, channel.author, channel.ucid)
+    return extract_items(initial_data, channel.author, channel.ucid, channel.author_thumbnail)
   end
 
   # -------------------
@@ -70,7 +72,7 @@ module Invidious::Channel::Tabs
     continuation ||= make_initial_livestreams_ctoken(channel.ucid, sort_by)
     initial_data = YoutubeAPI.browse(continuation: continuation)
 
-    return extract_items(initial_data, channel.author, channel.ucid)
+    return extract_items(initial_data, channel.author, channel.ucid, channel.author_thumbnail)
   end
 
   def get_60_livestreams(channel : AboutChannel, *, continuation : String? = nil, sort_by = "newest")

--- a/src/invidious/routes/companion.cr
+++ b/src/invidious/routes/companion.cr
@@ -13,8 +13,6 @@ module Invidious::Routes::Companion
         end
       end
     rescue ex
-      env.response.status_code = 502
-      return env.response.print("502 Bad Gateway")
     end
   end
 
@@ -32,8 +30,6 @@ module Invidious::Routes::Companion
         end
       end
     rescue ex
-      env.response.status_code = 502
-      return env.response.print("502 Bad Gateway")
     end
   end
 
@@ -50,8 +46,6 @@ module Invidious::Routes::Companion
         end
       end
     rescue ex
-      env.response.status_code = 502
-      return env.response.print("502 Bad Gateway")
     end
   end
 

--- a/src/invidious/routes/companion.cr
+++ b/src/invidious/routes/companion.cr
@@ -13,6 +13,8 @@ module Invidious::Routes::Companion
         end
       end
     rescue ex
+      env.response.status_code = 502
+      return env.response.print("502 Bad Gateway")
     end
   end
 
@@ -30,6 +32,8 @@ module Invidious::Routes::Companion
         end
       end
     rescue ex
+      env.response.status_code = 502
+      return env.response.print("502 Bad Gateway")
     end
   end
 
@@ -46,6 +50,8 @@ module Invidious::Routes::Companion
         end
       end
     rescue ex
+      env.response.status_code = 502
+      return env.response.print("502 Bad Gateway")
     end
   end
 

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -453,7 +453,7 @@ private module Parsers
       end
 
       content_container["items"]?.try &.as_a.each do |item|
-        result = parse_item(item, author_fallback.name, author_fallback.id)
+        result = parse_item(item, author_fallback.name, author_fallback.id, author_fallback.thumbnail)
         contents << result if result.is_a?(SearchItem)
       end
 

--- a/src/invidious/yt_backend/extractors.cr
+++ b/src/invidious/yt_backend/extractors.cr
@@ -26,7 +26,7 @@ private ITEM_PARSERS = {
 
 private alias InitialData = Hash(String, JSON::Any)
 
-record AuthorFallback, name : String, id : String
+record AuthorFallback, name : String, id : String, thumbnail : String? = nil
 
 # Namespace for logic relating to parsing InnerTube data into various datastructs.
 #
@@ -618,9 +618,9 @@ private module Parsers
         views:              view_count,
         description_html:   "",
         length_seconds:     duration,
-        premiere_timestamp: Time.unix(0),
+        premiere_timestamp: nil,
         author_verified:    false,
-        author_thumbnail:   nil,
+        author_thumbnail:   author_fallback.thumbnail,
         badges:             VideoBadges::None,
       })
     end
@@ -684,9 +684,9 @@ private module Parsers
           views:              view_count,
           description_html:   "",
           length_seconds:     length_seconds || 0,
-          premiere_timestamp: Time.unix(0),
+          premiere_timestamp: nil,
           author_verified:    false,
-          author_thumbnail:   nil,
+          author_thumbnail:   author_fallback.thumbnail,
           badges:             VideoBadges::None,
         })
         # If it's a playlist, it's content_type would be "LOCKUP_CONTENT_TYPE_PLAYLIST"
@@ -881,9 +881,9 @@ private module Parsers
         views:              view_count,
         description_html:   "",
         length_seconds:     duration,
-        premiere_timestamp: Time.unix(0),
+        premiere_timestamp: nil,
         author_verified:    false,
-        author_thumbnail:   nil,
+        author_thumbnail:   author_fallback.thumbnail,
         badges:             VideoBadges::None,
       })
     end
@@ -1147,11 +1147,11 @@ end
 
 # Parses an item from Youtube's JSON response into a more usable structure.
 # The end result can either be a SearchVideo, SearchPlaylist or SearchChannel.
-def parse_item(item : JSON::Any, author_fallback : String? = "", author_id_fallback : String? = "")
+def parse_item(item : JSON::Any, author_fallback : String? = "", author_id_fallback : String? = "", author_thumbnail_fallback : String? = nil)
   # We "allow" nil values but secretly use empty strings instead. This is to save us the
   # hassle of modifying every author_fallback and author_id_fallback arg usage
   # which is more often than not nil.
-  author_fallback = AuthorFallback.new(author_fallback || "", author_id_fallback || "")
+  author_fallback = AuthorFallback.new(author_fallback || "", author_id_fallback || "", author_thumbnail_fallback)
 
   # Cycles through all of the item parsers and attempt to parse the raw YT JSON data.
   # Each parser automatically validates the data given to see if the data is
@@ -1201,12 +1201,13 @@ def extract_items(
   initial_data : InitialData,
   author_fallback : String? = nil,
   author_id_fallback : String? = nil,
+  author_thumbnail_fallback : String? = nil,
 ) : {Array(SearchItem), String?}
   items = [] of SearchItem
   continuation = nil
 
   extract_items(initial_data) do |item|
-    parsed = parse_item(item, author_fallback, author_id_fallback)
+    parsed = parse_item(item, author_fallback, author_id_fallback, author_thumbnail_fallback)
 
     case parsed
     when .is_a?(Continuation) then continuation = parsed.token


### PR DESCRIPTION
Fixes #5899

When fetching videos from a channel, the channel videos are encapsulated in `lockupViewModel`. The inner `lockupViewModel` does not contain the channel profile picture, but the channel header does. This PR propagates the `author_thumbnail` from the `Channel` object down to `extract_items` and `parse_item` using `AuthorFallback`, so that `author_thumbnail` is correctly populated for `SearchVideo` items.

Additionally, this PR fixes `premiere_timestamp` falling back to the UNIX epoch (`1970-01-01 00:00:00Z`) for videos that were not premiered, properly setting it to `nil` instead, as defined in the `SearchVideo` struct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Channel videos, Shorts, and livestreams now display author thumbnails more consistently.
  * Author thumbnails are preserved across channel browsing and content listings when available.
  * Missing premiere timestamps are handled more reliably to improve content display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change carries the channel thumbnail into video, Shorts, livestream, reel, and lockup parsing when individual items omit author metadata, and leaves unavailable premiere timestamps unset. The earlier report that `InvidiousChannel#get_videos` could not compile is disproved: no-codegen builds succeeded both before and after the final wrapper change, and the current wrapper has no `author_thumbnail` call.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

Focused parsing checks confirmed fallback thumbnail propagation and absent premiere timestamps across lockup, Shorts lockup, and reel items; application compilation also completed successfully.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran no-codegen Crystal application compilation at commit b793ad5c and at the current PR head; both completed with exit code 0 and no undefined author\_thumbnail errors.
- I ran the uploaded synthetic Crystal parser validation against real parse\_item paths for lockupViewModel, shortsLockupViewModel, and reelItemRenderer inputs, and it passed all three cases with the supplied fallback thumbnail preserved and premiere timestamp nil.
- I attempted the existing regular-video parser spec, but it could not load its missing tracked mocks/video fixtures, so it did not provide regression evidence.
- I uploaded artifacts documenting the compilation and parser validation work, including the focused Crystal channel parser validation source and related logs.

<a href="https://app.greptile.com/trex/runs/18341931/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["Avoid unavailable thumbnail on stored ch..."](https://github.com/iv-org/invidious/commit/79f9ec576ea9069f2f73416596b752a85a28516a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52266724)</sub>

<!-- /greptile_comment -->