### PR TITLE
Fix inconsistent page param behavior for YouTube playlists in APIv1

### DIFF
--- a/src/invidious/routes/api/v1/misc.cr
+++ b/src/invidious/routes/api/v1/misc.cr
@@ -33,10 +33,6 @@ module Invidious::Routes::API::V1::Misc
     env.response.content_type = "application/json"
     plid = env.params.url["plid"]
 
-    offset = env.params.query["index"]?.try &.to_i?
-    offset ||= env.params.query["page"]?.try &.to_i?.try { |page| (page - 1) * 100 }
-    offset ||= 0
-
     video_id = env.params.query["continuation"]?
 
     format = env.params.query["format"]?
@@ -56,6 +52,19 @@ module Invidious::Routes::API::V1::Misc
     rescue ex
       return error_json(404, "Playlist does not exist.")
     end
+
+    offset = env.params.query["index"]?.try &.to_i?
+    if offset.nil?
+      page = env.params.query["page"]?.try &.to_i?
+      if page
+        if playlist.is_a? InvidiousPlaylist
+          offset = (page - 1) * 100
+        else
+          offset = (page - 1) * 200
+        end
+      end
+    end
+    offset ||= 0
 
     user = env.get?("user").try &.as(User)
     if !playlist || playlist.privacy.private? && playlist.author != user.try &.email


### PR DESCRIPTION
Fixes #5816

When calling the `/api/v1/playlists/:plid` endpoint with a `page` parameter, the `offset` calculation hardcoded `(page - 1) * 100` for all playlists. However, YouTube playlists fetch up to 200 items per call. This caused pagination behavior to be inconsistent (returning indexes `[51;250]` for `page=2`, etc.) because the calculation assumed a 100-item page while actually fetching 200.

This PR modifies the `offset` calculation so it first retrieves the `playlist` object, and then calculates the `offset` using `(page - 1) * 200` for standard YouTube playlists and `(page - 1) * 100` for Invidious playlists, correctly aligning APIv1's page size with the amount of videos retrieved.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change corrects APIv1 playlist pagination so the `page` parameter advances by the number of videos returned for the resolved playlist type. YouTube playlists now use 200-item page offsets, Invidious playlists retain 100-item offsets, and an explicit `index` continues to override `page`.

A Crystal regression harness compared the prior and updated offset behavior and confirmed the intended results for YouTube playlists, Invidious playlists, and explicit indexes. The application also compiled successfully. No defects were found.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The pagination behavior is consistent with each playlist implementation’s returned item count and compiled successfully.

The changed offset-selection behavior was exercised for both playlist types and for explicit-index precedence; no independent defects remain.

**Files Needing Attention:** No files require follow-up attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - Ran a Crystal regression harness against the prior revision and the updated code.
- - Compared behavior differences: YouTube playlist page=2 offset moves from 100 to 200, explicit index precedence is kept, and Invidious playlist page=2 offset remains 100.
- - Built the updated application with crystal build --no-codegen src/invidious.cr; the build completed with deprecation warnings only.
- - Compared pre- and post-capture results to validate PR contracts; the before capture showed the prior single 100-item page conversion, and the after capture showed all three requested PR contracts passing.
- - Verified and noted artifacts that contain the review-executable source and both command-output captures uploaded for review.

<a href="https://app.greptile.com/trex/runs/18336932/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix inconsistent page param behavior for..."](https://github.com/iv-org/invidious/commit/4ec99d78984f63ac972468cc2ac0cc4ad8b6a518) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52269086)</sub>

<!-- /greptile_comment -->