### PR TITLE
Fix empty author and authorId in playlists by falling back to avatar command

### DIFF
--- a/src/invidious/playlists.cr
+++ b/src/invidious/playlists.cr
@@ -445,7 +445,7 @@ def get_playlist_videos(playlist : InvidiousPlaylist | Playlist, offset : Int32,
       # 100 videos per request
       ctoken = produce_playlist_continuation(playlist.id, offset)
       initial_data = YoutubeAPI.browse(ctoken)
-      videos += extract_playlist_videos(playlist.id, initial_data)
+      videos += extract_playlist_videos(playlist, initial_data)
 
       offset += 100
     end
@@ -458,7 +458,7 @@ end
 # the same LockupViewModel used in Channel videos and Youtube playlists that
 # appears on searches (Invidious /search endpoint).
 # Related to https://github.com/iv-org/invidious/pull/5736
-def extract_playlist_videos(playlist_id : String, initial_data : Hash(String, JSON::Any))
+def extract_playlist_videos(playlist : InvidiousPlaylist | Playlist, initial_data : Hash(String, JSON::Any))
   videos = [] of PlaylistVideo | ProblematicTimelineItem
 
   if initial_data["contents"]?
@@ -489,7 +489,7 @@ def extract_playlist_videos(playlist_id : String, initial_data : Hash(String, JS
 
       watch_endpoint = i.dig?("rendererContext", "commandContext", "onTap", "innertubeCommand", "watchEndpoint")
       video_id = watch_endpoint.try &.["videoId"]?.try &.as_s
-      plid = watch_endpoint.try &.["playlistId"]?.try &.as_s || playlist_id
+      plid = watch_endpoint.try &.["playlistId"]?.try &.as_s || playlist.id
       index = watch_endpoint.try &.["index"]?.try &.as_i64
 
       metadata = i["metadata"]?
@@ -505,11 +505,33 @@ def extract_playlist_videos(playlist_id : String, initial_data : Hash(String, JS
         parts && parts.any? { |item2| item2.dig?("text", "commandRuns").try &.as_a }
       }.try &.["metadataParts"].as_a
 
+      author = nil
+      ucid = nil
       if author_info = metadata_parts.try &.find(&.dig?("text", "commandRuns"))
            .try &.["text"]
         author = author_info["content"].as_s
         ucid = author_info.dig?("commandRuns", 0, "onTap", "innertubeCommand", "browseEndpoint", "browseId")
           .try &.as_s
+      end
+
+      unless author && ucid
+        avatar_cmd = lockup_metadata_view_model.try &.dig?(
+          "image", "decoratedAvatarViewModel", "rendererContext", "commandContext", "onTap", "innertubeCommand"
+        )
+        if avatar_cmd
+          ucid ||= avatar_cmd.dig?("browseEndpoint", "browseId").try &.as_s
+          
+          if ucid && playlist.responds_to?(:ucid) && ucid == playlist.ucid
+            author ||= playlist.author
+          end
+          
+          if !author || author.empty?
+            handle = avatar_cmd.dig?("commandMetadata", "webCommandMetadata", "url").try &.as_s
+            if handle && handle.starts_with?("/@")
+              author = handle.lchop("/@")
+            end
+          end
+        end
       end
 
       length = thumbnail_view_model.try &.dig?("overlays", 0, "thumbnailBottomOverlayViewModel", "badges", 0, "thumbnailBadgeViewModel", "text").try &.as_s


### PR DESCRIPTION
Fixes #5593

In some cases, YouTube's `lockupViewModel` for videos within a playlist does not contain the `commandRuns` inside `metadataRows` which is usually used to extract the `author` and `ucid` (e.g. for certain videos like `HyK_Q5rrcr4` in playlist `PLRqwX-V7Uu6ZiZxtDDRCi6uhfTH4FilpH`). This resulted in the `api/v1/playlists` endpoint returning empty values for these fields.

This PR adds a fallback inside `extract_playlist_videos` that extracts the `ucid` from the `decoratedAvatarViewModel` command endpoint if the primary extraction fails. Additionally, it attempts to use the playlist's author if the extracted `ucid` matches the playlist's `ucid`, or falls back to parsing the channel handle.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds a fallback that reads playlist-video channel metadata from the decorated avatar when inline metadata is absent. The fallback works for the tested owner, non-owner, and partial-metadata cases, but an empty inline author value causes an owner video to display its channel handle rather than the known playlist owner name.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change should not merge until the empty-author fallback preserves the playlist owner's display name.

A focused Crystal harness exercised the changed extraction behavior with representative browse payloads and reproduced one incorrect author-display result.

**Files Needing Attention:** src/invidious/playlists.cr
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex posted a proof for a P2 finding and attached the Crystal harness source for playlist author fallback cases, along with the harness output log that shows the empty-owner-name failure.
- T-Rex produced a second finding-proof for another posted P2 finding.
- The contract-validation step confirms that the output shows author as 'Playlist Owner' (expected) but the actual value is 'ownerhandle', while authorId remains 'UC\_OWNER'.

<a href="https://app.greptile.com/trex/runs/18339519/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Empty metadata author is replaced by the owner handle**

   - **Bug**
     - For an owner avatar (`browseId == playlist.ucid`) with an empty metadata author and `/@ownerhandle` URL, the parser returns `author = "ownerhandle"` instead of the known playlist owner name `"Playlist Owner"`; `authorId` remains `"UC_OWNER"`.
   - **Cause**
     - `author ||= playlist.author` at `src/invidious/playlists.cr:525` does not replace an empty Crystal string because it is truthy. The following empty-author branch at line 528 then derives and assigns the handle.
   - **Fix**
     - At line 525, set the owner name when `author.nil? || author.empty?`, then only derive the handle if the author is still nil or empty.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Fix empty author and authorId in playlis..."](https://github.com/iv-org/invidious/commit/ef2a535596c9c5cea3f28dcd876e47a7581abf3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52275376)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->