### PR TITLE
Render custom channel emoji in comments and descriptions

### DIFF
--- a/spec/invidious/videos/description_spec.cr
+++ b/spec/invidious/videos/description_spec.cr
@@ -1,0 +1,103 @@
+require "../../parsers_helper.cr"
+
+Spectator.describe "parse_description" do
+  it "renders custom channel emoji as an image" do
+    # Custom emoji only exist in the attachment run; the text content carries
+    # the ":shortcode:" placeholder, which must not be shown as-is.
+    raw = {
+      "content"        => ":face-red-heart-shape: hello",
+      "attachmentRuns" => [
+        {
+          "startIndex" => 0,
+          "length"     => 22,
+          "element"    => {
+            "type" => {
+              "imageType" => {
+                "image" => {
+                  "sources" => [
+                    {"url" => "https://lh3.googleusercontent.com/abc=s16-w24-h24-c-k-nd", "width" => 16, "height" => 16},
+                  ],
+                },
+              },
+            },
+            "properties" => {
+              "accessibilityProperties" => {"label" => "face-red-heart-shape"},
+            },
+          },
+        },
+      ],
+    }
+
+    result = parse_description(JSON.parse(raw.to_json), "")
+
+    expect(result).to eq(
+      %(<img alt="face-red-heart-shape" src="/ggpht/abc=s16-w24-h24-c-k-nd" ) +
+      %(title="face-red-heart-shape" width="16" height="16" class="channel-emoji" /> hello)
+    )
+  end
+
+  it "leaves standard unicode emoji untouched" do
+    # Standard emoji also come with an attachment run, but the text content is
+    # already the emoji character, so it must be kept as text.
+    raw = {
+      "content"        => "Nice sharing 🎉",
+      "attachmentRuns" => [
+        {
+          "startIndex" => 13,
+          "length"     => 2,
+          "element"    => {
+            "type" => {
+              "imageType" => {
+                "image" => {
+                  "sources" => [
+                    {"url" => "https://www.youtube.com/s/gaming/emoji/7ff574f2/emoji_u1f389.png", "width" => 16, "height" => 16},
+                  ],
+                },
+              },
+            },
+            "properties" => {
+              "accessibilityProperties" => {"label" => "🎉"},
+            },
+          },
+        },
+      ],
+    }
+
+    result = parse_description(JSON.parse(raw.to_json), "")
+
+    expect(result).to eq("Nice sharing 🎉")
+  end
+
+  it "keeps text offsets correct when an emoji precedes other content" do
+    # The emoji run is consumed from the same iterator as the surrounding
+    # text, so a wrong length here would shift everything after it.
+    raw = {
+      "content"        => "a:face-red-heart-shape:b",
+      "attachmentRuns" => [
+        {
+          "startIndex" => 1,
+          "length"     => 22,
+          "element"    => {
+            "type" => {
+              "imageType" => {
+                "image" => {
+                  "sources" => [
+                    {"url" => "https://lh3.googleusercontent.com/abc", "width" => 16, "height" => 16},
+                  ],
+                },
+              },
+            },
+            "properties" => {
+              "accessibilityProperties" => {"label" => "face-red-heart-shape"},
+            },
+          },
+        },
+      ],
+    }
+
+    result = parse_description(JSON.parse(raw.to_json), "")
+
+    expect(result).to start_with("a<img ")
+    expect(result).to end_with("/>b")
+  end
+end

--- a/src/invidious/videos/description.cr
+++ b/src/invidious/videos/description.cr
@@ -40,6 +40,37 @@ private def copy_string(str : String::Builder, iter : Iterator, count : Int) : I
   return copied
 end
 
+# Custom channel emoji are sent as an attachment run holding the image, while
+# the text content only carries a ":shortcode:" placeholder. If the image is
+# not substituted in, that raw placeholder is what gets displayed.
+#
+# Standard Unicode emoji are sent as attachment runs too, but their text
+# content is the emoji character itself, which already renders correctly. Those
+# are left as-is, so we don't proxy an image for every single emoji.
+private def attachment_run_to_html(run : JSON::Any, text : String) : String
+  return text if !(text.starts_with?(':') && text.ends_with?(':') && text.size > 2)
+
+  source = run.dig?("element", "type", "imageType", "image", "sources", 0)
+  return text if source.nil?
+
+  url = source["url"]?.try &.as_s
+  return text if url.nil?
+
+  label = run.dig?("element", "properties", "accessibilityProperties", "label")
+    .try &.as_s || text
+  width = source["width"]?.try &.as_i? || 16
+  height = source["height"]?.try &.as_i? || 16
+
+  return String.build do |str|
+    str << %(<img alt=") << HTML.escape(label) << %(" )
+    str << %(src="/ggpht) << URI.parse(url).request_target << %(" )
+    str << %(title=") << HTML.escape(label) << %(" )
+    str << %(width=") << width << %(" )
+    str << %(height=") << height << %(" )
+    str << %(class="channel-emoji" />)
+  end
+end
+
 def parse_description(desc, video_id : String) : String?
   return "" if desc.nil?
 
@@ -47,7 +78,9 @@ def parse_description(desc, video_id : String) : String?
   return "" if content.empty?
 
   commands = desc["commandRuns"]?.try &.as_a
-  if commands.nil?
+  attachments = desc["attachmentRuns"]?.try &.as_a
+
+  if commands.nil? && attachments.nil?
     # Slightly faster than HTML.escape, as we're only doing one pass on
     # the string instead of five for the standard library
     return String.build do |str|
@@ -55,6 +88,17 @@ def parse_description(desc, video_id : String) : String?
       copy_string(str, content.each_codepoint, content_size)
     end
   end
+
+  # Both kinds of run index into the same string, so they have to be walked
+  # together in positional order.
+  runs = [] of {Int32, Int32, Bool, JSON::Any}
+  commands.try &.each do |command|
+    runs << {command["startIndex"].as_i, command["length"].as_i, false, command}
+  end
+  attachments.try &.each do |attachment|
+    runs << {attachment["startIndex"].as_i, attachment["length"].as_i, true, attachment}
+  end
+  runs.sort_by! { |run| run[0] }
 
   # Not everything is stored in UTF-8 on youtube's side. The SMP codepoints
   # (0x10000 and above) are encoded as UTF-16 surrogate pairs, which are
@@ -65,26 +109,32 @@ def parse_description(desc, video_id : String) : String?
   index = 0
 
   return String.build do |str|
-    commands.each do |command|
-      cmd_start = command["startIndex"].as_i
-      cmd_length = command["length"].as_i
+    runs.each do |(run_start, run_length, is_attachment, run)|
+      # A command and an attachment can cover the same characters. The
+      # iterator can only move forward, so skip anything already consumed.
+      next if run_start < index
 
-      # Copy the text chunk between this command and the previous if needed.
-      length = cmd_start - index
+      # Copy the text chunk between this run and the previous if needed.
+      length = run_start - index
       index += copy_string(str, iter, length)
 
-      # We need to copy the command's text using the iterator
+      # We need to copy the run's text using the iterator
       # and the special function defined above.
-      cmd_content = String.build(cmd_length) do |str2|
-        copy_string(str2, iter, cmd_length)
+      run_content = String.build(run_length) do |str2|
+        copy_string(str2, iter, run_length)
       end
 
-      link = cmd_content
-      if on_tap = command.dig?("onTap", "innertubeCommand")
-        link = parse_link_endpoint(on_tap, cmd_content, video_id)
+      if is_attachment
+        str << attachment_run_to_html(run, run_content)
+      else
+        link = run_content
+        if on_tap = run.dig?("onTap", "innertubeCommand")
+          link = parse_link_endpoint(on_tap, run_content, video_id)
+        end
+        str << link
       end
-      str << link
-      index += cmd_length
+
+      index += run_length
     end
 
     # Copy the end of the string (past the last command).


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

- [ ] AI was not used to create this pull request
- [x] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

**Model(s) used (and thinking/reasoning level if relevant):**
Claude Opus 5 (extended thinking)

**Tool(s) used:**
Claude Code (CLI)

**How was AI used?**
The code and the specs were written by the AI. I built and ran it locally and
checked the result myself before submitting (see Testing below).

---

## Pull request description

Fixes: #5888
I want to be awarded the bounty associated to the issue this PR is fixing.

Custom channel emoji just shows as raw text like `:face-red-heart-shape:`
instead of images, both in the comments and in the video descriptions.

`parse_description` only handled the `commandRuns`. The emoji image is in
`attachmentRuns`, which nothing read and there is evan a matching
`# todo parse styleRuns, commandRuns and attachmentRuns for comments`
left in the `comments/youtube.cr`.

Both kinds of run index into the same string and the codepoint iterator only
moves forward, so they are now merged and walked in positional order.

Standard unicode emoji are sent as attachment runs too, but their text content
is already the emoji character and renders fine, so I left those as text.
Converting them would mean proxying an image for every emoji in every comment.

### Testing

Built and ran locally, then compared the comment from the issue side by side
with YouTube.
https://www.youtube.com/watch?v=Gy3bmuzmWMM&lc=UgxVdYO3R6wrr9sLhT54AaABAg
Invidious (This PR):
<img width="1470" height="923" alt="Invidious (This PR)" src="https://github.com/user-attachments/assets/abdb8d2a-d078-4a51-bb99-4506f0ff1e66" />
Youtube:
<img width="1470" height="923" alt="Youtube" src="https://github.com/user-attachments/assets/89caa460-caf8-47be-8d94-ce1b3e08e45b" />

- `crystal tool format --check` passes
- `crystal spec` - 175 examples, 0 failures
- 3 regression specs added in `spec/invidious/videos/description_spec.cr`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Custom channel emojis in video descriptions now render as images.
  - Standard Unicode emoji remain displayed as text.
  - Description text and links now maintain correct positioning when emojis appear before other content.
  - Incomplete or unsupported emoji data is safely displayed as regular text instead of producing broken content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds support for attachment runs so custom channel emoji can render through the local image proxy while standard Unicode emoji remains text. A focused parser reproduction found that custom emoji still render incorrectly when YouTube supplies a command run over the same shortcode: the description shows a linked raw shortcode instead of the emoji image. `src/invidious/videos/description.cr` needs to handle overlapping command and attachment ranges before this can be merged safely.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge until overlapping command and attachment runs render the custom emoji correctly.

A focused executable reproduction invoked the production parser, verified the attachment-only control, and then showed that adding an equal-range command run exposes the raw shortcode in a link.

**Files Needing Attention:** `src/invidious/videos/description.cr`, particularly the ordering and forward-only consumption of command and attachment runs around line 115.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding.
- T-Rex produced a proof for a second posted P1 finding.
- T-Rex validated contract behavior by running the attachment-only control and the overlapping run, confirming the expected HTML output and the link behavior when the shared range is involved.

<a href="https://app.greptile.com/trex/runs/18404902/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Overlapping command run suppresses custom emoji attachment rendering**

   - **Bug**
     - For content `:party:`, an attachment-only run renders the expected custom emoji image. Adding a same-range command run causes the result to be `<a href="/results?search_query=party">:party:</a>`, exposing the shortcode in a link instead of rendering custom emoji HTML.
   - **Cause**
     - Runs are ordered only by start index. The command run is processed first for equal starts, advances `index` over the shortcode, and `next if run_start < index` at `src/invidious/videos/description.cr:115` skips the attachment run.
   - **Fix**
     - Handle overlapping attachment and command ranges together, or give custom-emoji attachment runs precedence for equal/overlapping ranges while preserving any intended command-link behavior.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Render custom channel emoji in comments ..."](https://github.com/iv-org/invidious/commit/f18762bcde3c4e38e7e5d5379fa80ed6f982b45e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52399583)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->