### PR TITLE
fix: exclude trailing punctuation from auto-detected links

### DIFF
--- a/spec/invidious/comments/content_spec.cr
+++ b/spec/invidious/comments/content_spec.cr
@@ -1,0 +1,118 @@
+require "../../parsers_helper"
+
+Spectator.describe "strip_url_trailing_punctuation" do
+  it "strips trailing punctuation from URLs" do
+    expect(strip_url_trailing_punctuation("https://example.com.")).to eq("https://example.com")
+    expect(strip_url_trailing_punctuation("https://example.com,")).to eq("https://example.com")
+    expect(strip_url_trailing_punctuation("https://example.com...")).to eq("https://example.com")
+    expect(strip_url_trailing_punctuation("https://example.com/page)!?")).to eq("https://example.com/page")
+  end
+
+  it "keeps URLs without trailing punctuation untouched" do
+    expect(strip_url_trailing_punctuation("https://example.com")).to eq("https://example.com")
+    expect(strip_url_trailing_punctuation("https://example.com/a.b?c=d,e#f")).to eq("https://example.com/a.b?c=d,e#f")
+  end
+
+  it "keeps balanced closing parentheses" do
+    expect(strip_url_trailing_punctuation("https://en.wikipedia.org/wiki/Crystal_(programming_language)"))
+      .to eq("https://en.wikipedia.org/wiki/Crystal_(programming_language)")
+
+    # Only the unmatched parenthesis is stripped
+    expect(strip_url_trailing_punctuation("https://en.wikipedia.org/wiki/Crystal_(programming_language))"))
+      .to eq("https://en.wikipedia.org/wiki/Crystal_(programming_language)")
+  end
+end
+
+Spectator.describe "text_to_parsed_content" do
+  it "parses text without URLs" do
+    runs = text_to_parsed_content("Hello world").dig("runs").as_a
+
+    expect(runs.size).to eq(1)
+    expect(runs[0].dig("text").as_s).to eq("Hello world\n")
+  end
+
+  it "auto-links a bare URL" do
+    runs = text_to_parsed_content("https://example.com").dig("runs").as_a
+
+    expect(runs.size).to eq(3)
+    expect(runs[0].dig("text").as_s).to eq("")
+    expect(runs[1].dig("text").as_s).to eq("https://example.com")
+    expect(runs[1].dig("navigationEndpoint", "urlEndpoint", "url").as_s).to eq("https://example.com")
+    expect(runs[2].dig("text").as_s).to eq("\n")
+  end
+
+  it "excludes sentence punctuation from auto-linked URLs" do
+    runs = text_to_parsed_content("Check out https://example.com. Thanks!").dig("runs").as_a
+
+    expect(runs.size).to eq(3)
+    expect(runs[0].dig("text").as_s).to eq("Check out ")
+    expect(runs[1].dig("navigationEndpoint", "urlEndpoint", "url").as_s).to eq("https://example.com")
+    expect(runs[2].dig("text").as_s).to eq(". Thanks!\n")
+  end
+
+  it "excludes the closing parenthesis of enclosing text" do
+    runs = text_to_parsed_content("(visit my website at https://example.com)").dig("runs").as_a
+
+    expect(runs.size).to eq(3)
+    expect(runs[0].dig("text").as_s).to eq("(visit my website at ")
+    expect(runs[1].dig("navigationEndpoint", "urlEndpoint", "url").as_s).to eq("https://example.com")
+    expect(runs[2].dig("text").as_s).to eq(")\n")
+  end
+
+  it "keeps URLs containing balanced parentheses intact" do
+    runs = text_to_parsed_content("(see https://en.wikipedia.org/wiki/Crystal_(programming_language))").dig("runs").as_a
+
+    expect(runs.size).to eq(3)
+    expect(runs[1].dig("navigationEndpoint", "urlEndpoint", "url").as_s)
+      .to eq("https://en.wikipedia.org/wiki/Crystal_(programming_language)")
+    expect(runs[2].dig("text").as_s).to eq(")\n")
+  end
+
+  it "keeps punctuation inside URLs" do
+    runs = text_to_parsed_content("Docs: https://example.com/a.b?c=d,e#f! Read").dig("runs").as_a
+
+    expect(runs.size).to eq(3)
+    expect(runs[1].dig("navigationEndpoint", "urlEndpoint", "url").as_s).to eq("https://example.com/a.b?c=d,e#f")
+    expect(runs[2].dig("text").as_s).to eq("! Read\n")
+  end
+
+  it "does not include angle brackets in auto-linked URLs" do
+    runs = text_to_parsed_content("<https://example.com>").dig("runs").as_a
+
+    expect(runs.size).to eq(3)
+    expect(runs[0].dig("text").as_s).to eq("<")
+    expect(runs[1].dig("navigationEndpoint", "urlEndpoint", "url").as_s).to eq("https://example.com")
+    expect(runs[2].dig("text").as_s).to eq(">\n")
+  end
+
+  it "auto-links multiple URLs on the same line" do
+    runs = text_to_parsed_content("See https://a.example, then https://b.example.").dig("runs").as_a
+
+    expect(runs.size).to eq(5)
+    expect(runs[0].dig("text").as_s).to eq("See ")
+    expect(runs[1].dig("navigationEndpoint", "urlEndpoint", "url").as_s).to eq("https://a.example")
+    expect(runs[2].dig("text").as_s).to eq(", then ")
+    expect(runs[3].dig("navigationEndpoint", "urlEndpoint", "url").as_s).to eq("https://b.example")
+    expect(runs[4].dig("text").as_s).to eq(".\n")
+  end
+
+  it "keeps the text surrounding a repeated URL" do
+    runs = text_to_parsed_content("https://example.com and https://example.com.").dig("runs").as_a
+
+    expect(runs.size).to eq(5)
+    expect(runs[1].dig("navigationEndpoint", "urlEndpoint", "url").as_s).to eq("https://example.com")
+    expect(runs[2].dig("text").as_s).to eq(" and ")
+    expect(runs[3].dig("navigationEndpoint", "urlEndpoint", "url").as_s).to eq("https://example.com")
+    expect(runs[4].dig("text").as_s).to eq(".\n")
+  end
+
+  it "handles URLs on multiple lines" do
+    runs = text_to_parsed_content("Line one https://example.com,\nLine two").dig("runs").as_a
+
+    expect(runs.size).to eq(4)
+    expect(runs[0].dig("text").as_s).to eq("Line one ")
+    expect(runs[1].dig("navigationEndpoint", "urlEndpoint", "url").as_s).to eq("https://example.com")
+    expect(runs[2].dig("text").as_s).to eq(",\n")
+    expect(runs[3].dig("text").as_s).to eq("Line two\n")
+  end
+end

--- a/src/invidious/comments/content.cr
+++ b/src/invidious/comments/content.cr
@@ -1,3 +1,33 @@
+# Strip punctuation at the end of an auto-detected URL that most likely
+# belongs to the surrounding text rather than to the URL itself (e.g the
+# period at the end of a sentence, or the closing parenthesis in
+# "(see https://example.com)").
+#
+# The rules mimic the autolink extension of GitHub Flavored Markdown
+# (https://github.github.com/gfm/#extended-autolink-path-validation),
+# with the addition of ';' since entity references can't appear in the
+# plain text handled here.
+#
+# A trailing closing parenthesis is only stripped when it has no matching
+# opening parenthesis within the URL, so that links like
+# https://en.wikipedia.org/wiki/Crystal_(programming_language) are kept
+# intact.
+def strip_url_trailing_punctuation(url : String) : String
+  loop do
+    case url[-1]?
+    when '.', ',', ':', ';', '!', '?', '\'', '"', '*', '_', '~'
+      url = url.rchop
+    when ')'
+      break if url.count('(') >= url.count(')')
+      url = url.rchop
+    else
+      break
+    end
+  end
+
+  return url
+end
+
 def text_to_parsed_content(text : String) : JSON::Any
   nodes = [] of JSON::Any
   # For each line convert line to array of nodes
@@ -12,14 +42,16 @@ def text_to_parsed_content(text : String) : JSON::Any
     # For each match with url pattern, get last node and preserve
     # last node before create new node with url information
     # { 'text': match, 'navigationEndpoint': { 'urlEndpoint' : 'url': match } }
-    line.scan(/https?:\/\/[^ ]*/).each do |url_match|
+    line.scan(/https?:\/\/[^\s<>]+/).each do |url_match|
+      url = strip_url_trailing_punctuation(url_match[0])
+
       # Retrieve last node and update node without match
       last_node = current_nodes[-1].as_h
-      splitted_last_node = last_node["text"].as_s.split(url_match[0])
+      splitted_last_node = last_node["text"].as_s.split(url, 2)
       last_node["text"] = JSON.parse(splitted_last_node[0].to_json)
       current_nodes[-1] = JSON.parse(last_node.to_json)
       # Create new node with match and navigation infos
-      current_node = {"text" => url_match[0], "navigationEndpoint" => {"urlEndpoint" => {"url" => url_match[0]}}}
+      current_node = {"text" => url, "navigationEndpoint" => {"urlEndpoint" => {"url" => url}}}
       current_nodes << (JSON.parse(current_node.to_json))
       # If text remain after match create new simple node with text after match
       after_node = {"text" => splitted_last_node.size > 1 ? splitted_last_node[1] : ""}


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

<!-- Tick exactly one -->

- [ ] AI was not used to create this pull request
- [x] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
Fable 5 Max (thinking)

**Tool(s) used:**
Cursor (agent mode)

**How was AI used?**

---

## Pull request description

Closes #5300

URL auto-linking in `text_to_parsed_content` matched everything up to the next space, so punctuation belonging to the surrounding sentence became part of the link:

- `(visit my website at https://example.com)` → the closing parenthesis was included in the URL
- `Check out https://example.com.` → the sentence period was included in the URL

### Changes

- Add a `strip_url_trailing_punctuation` helper that removes trailing `.` `,` `:` `;` `!` `?` `'` `"` `*` `_` `~` from auto-detected URLs, mirroring the trailing-punctuation rules of Markdown-style autolinks (as suggested in the issue discussion). A trailing closing parenthesis is only stripped when it has no matching opening parenthesis within the URL, so links like https://en.wikipedia.org/wiki/Crystal_(programming_language) are kept intact.
- The URL pattern stops at whitespace and angle brackets instead of only spaces, and no longer matches a bare `https://` with nothing after it.
- The text surrounding a link is split with a limit of 2, so a URL appearing twice on the same line no longer drops the text after its second occurrence.
- Add specs for `strip_url_trailing_punctuation` and `text_to_parsed_content` (13 examples; this file had no spec coverage before).

### Verification

Ran in a container matching the CI environment (Crystal 1.20.3, Ubuntu):

- `crystal tool format --check` — clean
- `bin/ameba` — 146 inspected, 0 failures
- `crystal spec` — 185 examples, 0 failures
- `crystal build --warnings all --error-on-warnings src/invidious.cr` — builds cleanly

Human verification: I ran the new spec file and a demo script printing the parsed runs for sample inputs on this branch, and confirmed the expected behavior (trailing punctuation excluded from links, balanced parentheses kept, no text lost around repeated URLs).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL detection in comments by removing trailing sentence punctuation.
  * Preserved balanced parentheses within URLs while excluding surrounding angle brackets.
  * Improved handling of multiple, repeated, and line-separated URLs.
  * Ensured detected links use the cleaned URL for navigation and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change improves automatic URL linking in channel descriptions by excluding surrounding trailing punctuation while retaining balanced closing parentheses in URLs.

The reported concern about terminal `_`, `~`, `*`, and `!` characters was disproved by executing the parser with each suffix. The emitted links exclude those suffixes, which matches the GitHub Flavored Markdown extended-autolink punctuation behavior that this helper is intended to implement.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The focused parser behavior is consistent with the documented autolink rules and is safe to merge.

No actionable defects remain after exercising the disputed URL-suffix behavior through the generated navigation endpoints.

**Files Needing Attention:** No files require further attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed a Crystal harness run of text\_to\_parsed\_content targeting URLs ending with \_, ~, \*, and ! to exercise the extended-autolink behavior.
- Observed navigation endpoints rewrite to the base path, e.g., /path\_ -\> /path, /path~ -\> /path, /path\* -\> /path, /path! -\> /path.
- Confirmed the Crystal command completed with exit code 0 and reported no blockers.
- Concluded that the observed behavior aligns with the intended extended-autolink punctuation rule rather than truncation.

<a href="https://app.greptile.com/trex/runs/18698050/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: exclude trailing punctuation from a..."](https://github.com/iv-org/invidious/commit/be4f5875a27d5f55484f3bffae290f2b46e5e410) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52961275)</sub>

<!-- /greptile_comment -->