### PR TITLE
fix: populate ucid for videos with multiple authors (fixes #5722)

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -399,6 +399,39 @@ module Invidious::Videos::Parser
     author = video_details["author"]?.try &.as_s
     ucid = video_details["channelId"]?.try &.as_s
 
+    # For videos with multiple authors (collaborations) YouTube does not
+    # expose a single `channelId` in `videoDetails`, which left `ucid` empty
+    # and made the channel link on the watch page disappear. Fall back to the
+    # owner/byline navigation endpoint, which still carries the first
+    # channel's browseId. See iv-org/invidious#5722.
+    if ucid.nil? || ucid.empty?
+      # Prefer the owner renderer (first channel of a collaboration).
+      if owner = video_secondary_renderer.try &.dig?("owner", "videoOwnerRenderer")
+        owner_ucid = owner.dig?("title", "runs", 0, "navigationEndpoint", "browseEndpoint", "browseId").try &.as_s
+        ucid = owner_ucid if owner_ucid && !owner_ucid.empty?
+      end
+
+      # Still missing? Walk every byline candidate and keep the first one that
+      # actually carries a usable browseId, instead of stopping at the first
+      # non-nil byline (whose first run may lack a navigation endpoint).
+      if ucid.nil? || ucid.empty?
+        byline_candidates = [
+          video_details["longBylineText"]?,
+          video_details["shortBylineText"]?,
+          video_secondary_renderer.try &.dig?("longBylineText"),
+          video_secondary_renderer.try &.dig?("shortBylineText"),
+        ]
+        byline_candidates.each do |candidate|
+          next if candidate.nil?
+          candidate_ucid = candidate.dig?("runs", 0, "navigationEndpoint", "browseEndpoint", "browseId").try &.as_s
+          if candidate_ucid && !candidate_ucid.empty?
+            ucid = candidate_ucid
+            break
+          end
+        end
+      end
+    end
+
     if author_info = video_secondary_renderer.try &.dig?("owner", "videoOwnerRenderer")
       author_thumbnail = author_info.dig?("thumbnail", "thumbnails", 0, "url")
       author_verified = has_verified_badge?(author_info["badges"]?)


### PR DESCRIPTION
Summary
Closes #5722.

For collaboration videos (multiple authors, e.g. "The Diary Of A CEO and Predictive History"), YouTube does not expose a single channelId in videoDetails. extract_video_info only read video_details["channelId"], so ucid ended up empty and the channel link on the watch page (/channel/<ucid>) was not rendered.

This adds a fallback: when channelId is missing, derive the first channel's browseId from the owner/byline navigation endpoint (videoOwnerRenderer.title.runs[0], then longBylineText/shortBylineText). The channel link now appears for multi-author videos.

Root cause
- src/invidious/videos/parser.cr:400 — ucid = video_details["channelId"]?.try &.as_s returns nil for multi-author videos.
- The watch template (src/invidious/views/watch.ecr:244) renders the channel link from video.ucid; an empty ucid drops the link.

Test plan
- [ ] Open a multi-author video (e.g. IZZVijQ0gkA) → channel name links to /channel/UC....
- [ ] Open a normal single-author video → link unchanged.

Note on local verification
The dev environment used to prepare this fix has no Crystal toolchain and cannot reach the Crystal distribution hosts, so I could not run make/the test suite locally. The change mirrors the existing byline-parsing pattern in parse_related_video (parser.cr:23-29) and HelperExtractors.get_browse_id. CI on this PR is the source of truth for the build/test check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel identification for collaborative videos when primary channel information is missing or empty.
  * Added fallback handling to use available channel details from alternate video metadata.
  * Preserved existing channel information whenever it is already available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update restores channel navigation for collaboration videos when YouTube omits the primary channel identifier, using owner and byline metadata as fallbacks. No blocking failure remains.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No accepted blocking findings remain.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A pre-capture spec search for UCID fallback constructs was performed, and the search returned an empty result.
- A subsequent validation attempt was executed, and Crystal reported a missing file at /home/user/repo/src/invidious/exceptions.cr.
- It was confirmed that no tracked source was changed; only untracked files under trex-artifacts were authored.

<a href="https://app.greptile.com/trex/runs/19092777/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: populate ucid for videos with multi..."](https://github.com/iv-org/invidious/commit/88c25e48f8f172505af45ea111079d13ab7849b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53740064)</sub>

<!-- /greptile_comment -->