### PR TITLE
Fix broken channel link for related videos with multiple creators (#5722)

### DIFF
--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -19,14 +19,27 @@ module Invidious::Videos::Parser
       decode_length_seconds(box.as_s).to_s
     end
 
-    # Both have "short", so the "long" option shouldn't be required
-    channel_info = (related["shortBylineText"]? || related["longBylineText"]?)
-      .try &.dig?("runs", 0)
+    # Both have "short", so the "long" option shouldn't be required.
+    # Videos with multiple creators expose each creator as a separate run
+    # inside "runs" (e.g. "Channel A", " and ", "Channel B"). The previous
+    # code only ever read runs[0], so any creator past the first one had no
+    # channel link. We now pick the first run that actually carries a
+    # channel id (browseId) so multi-creator videos still get a working link.
+    byline = (related["shortBylineText"]? || related["longBylineText"]?)
 
-    author = channel_info.try &.dig?("text")
+    author = byline.try { |b| b.dig?("runs", 0, "text") }
+
+    ucid = byline.try do |b|
+      runs = b.dig?("runs")
+      next nil unless runs
+      runs.as_a.each do |run|
+        if id = HelperExtractors.get_browse_id(run)
+          break id
+        end
+      end
+    end
+
     author_verified = has_verified_badge?(related["ownerBadges"]?).to_s
-
-    ucid = channel_info.try { |ci| HelperExtractors.get_browse_id(ci) }
 
     short_view_count = related.try do |r|
       HelperExtractors.get_short_view_count(r).to_s

--- a/src/invidious/videos/parser.cr
+++ b/src/invidious/videos/parser.cr
@@ -32,11 +32,16 @@ module Invidious::Videos::Parser
     ucid = byline.try do |b|
       runs = b.dig?("runs")
       next nil unless runs
+      found_id = nil
       runs.as_a.each do |run|
-        if id = HelperExtractors.get_browse_id(run)
-          break id
-        end
+        id = HelperExtractors.get_browse_id(run)
+        # get_browse_id returns "" (not nil) when no browseId is present, so an
+        # empty first run must not stop the scan. Only keep a non-empty id.
+        next if id.empty?
+        found_id = id
+        break
       end
+      found_id
     end
 
     author_verified = has_verified_badge?(related["ownerBadges"]?).to_s


### PR DESCRIPTION
Fixes #5722 — channel links for recommended videos created by multiple creators were missing.

parse_related_video only read runs[0] of the byline. Multi-creator videos expose several runs (e.g. 'Channel A', ' and', 'Channel B'), so creators past the first had no browseId and no channel link.

Now iterate all runs and pick the first carrying a channel id; the displayed author text is unchanged (still runs[0].text).

## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious/blob/master/AI_POLICY.md) and understand the disclosure requirements

## AI Disclosure

<!-- Tick exactly one -->

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
tencent/hy3 (Hermes Agent)

**Tool(s) used:**
Hermes Agent

**How was AI used?**
The fix in `src/invidious/videos/parser.cr` (parse_related_video: iterate all byline runs and pick the first carrying a browseId) was drafted and the project was compiled to verify it (`crystal build` passes). The user reviewed, opened the PR, and will claim the bounty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved related video metadata parsing for multi-creator videos.
  * Channel links now appear when creator information is provided across multiple byline entries.
  * Added fallback handling to display creator names more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Related-video parsing now preserves the first byline text for display while continuing through byline runs until it finds a usable creator channel ID. The exercised multi-creator and normal single-creator paths return the expected channel IDs.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The changed parser behavior was exercised with a byline whose first run has no channel ID and a later run does, as well as with a normal first-run channel ID; both returned the expected values.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Crystal command trex-artifacts/related-video-browseid-02-after.cr in /home/user/repo against the production parser and observed the two fixture outcomes.
- Validated the code path that reads author from runs\[0\].text and skips empty IDs to return the first non-empty browseId.
- Validated that the extractor returns an empty string when a run has no browseId, explaining why the explicit empty-ID skip is required.

<a href="https://app.greptile.com/trex/runs/19129748/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Continue scan past empty browseId in par..."](https://github.com/iv-org/invidious/commit/cc5beb56304d1a142fc0dfa2b00730acd44d14ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53818121)</sub>

<!-- /greptile_comment -->